### PR TITLE
Position firewall alerts as bottom-right toasts

### DIFF
--- a/HydraDragonFirewall/hydradragonfirewall/src/engine.rs
+++ b/HydraDragonFirewall/hydradragonfirewall/src/engine.rs
@@ -1,6 +1,6 @@
+use crate::file_magic::FileMagicChecker;
 use crate::injector::Injector;
 use crate::web_filter::WebFilter;
-use crate::file_magic::FileMagicChecker;
 use lazy_static::lazy_static;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -11,7 +11,8 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
+use tauri::dpi::{PhysicalPosition, PhysicalSize};
+use tauri::{AppHandle, Emitter, Manager, Position, WebviewUrl, WebviewWindowBuilder};
 use windivert::prelude::*;
 
 lazy_static! {
@@ -224,14 +225,14 @@ impl FirewallRule {
 
         // File Magic matching
         if !self.file_types.is_empty() {
-             if let Some(ref ftype) = packet.detected_file_type {
+            if let Some(ref ftype) = packet.detected_file_type {
                 if !self.file_types.contains(ftype) {
                     return false;
                 }
-             } else {
-                 // Rule requires file type match, but packet has none
-                 return false;
-             }
+            } else {
+                // Rule requires file type match, but packet has none
+                return false;
+            }
         }
 
         true
@@ -450,8 +451,8 @@ pub struct AppManager {
     pub port_map: RwLock<HashMap<u16, u32>>,
     pub info_cache: AppInfoCache,
     pub url_cache: RwLock<HashMap<u32, String>>, // PID -> URL
-    pub injected_pids: RwLock<HashSet<u32>>,      // Avoid repeated injections
-    pub failed_pids: RwLock<HashSet<u32>>,        // PIDs where injection failed
+    pub injected_pids: RwLock<HashSet<u32>>,     // Avoid repeated injections
+    pub failed_pids: RwLock<HashSet<u32>>,       // PIDs where injection failed
 }
 
 impl AppManager {
@@ -720,7 +721,7 @@ impl FirewallEngine {
     /// Resolve PID from port using Windows TCP/UDP extended tables
     pub fn resolve_pid_from_port(port: u16, is_tcp: bool) -> u32 {
         use std::mem::size_of;
-        
+
         unsafe {
             // TCP lookup
             if is_tcp {
@@ -734,7 +735,7 @@ impl FirewallEngine {
                     windows::Win32::NetworkManagement::IpHelper::TCP_TABLE_OWNER_PID_ALL,
                     0,
                 );
-                
+
                 if size > 0 {
                     let mut buffer = vec![0u8; size as usize];
                     if windows::Win32::NetworkManagement::IpHelper::GetExtendedTcpTable(
@@ -744,14 +745,13 @@ impl FirewallEngine {
                         windows::Win32::Networking::WinSock::AF_INET.0 as u32,
                         windows::Win32::NetworkManagement::IpHelper::TCP_TABLE_OWNER_PID_ALL,
                         0,
-                    ) == 0 {
+                    ) == 0
+                    {
                         let table = buffer.as_ptr() as *const windows::Win32::NetworkManagement::IpHelper::MIB_TCPTABLE_OWNER_PID;
                         let num_entries = (*table).dwNumEntries as usize;
-                        let entries = std::slice::from_raw_parts(
-                            (*table).table.as_ptr(),
-                            num_entries,
-                        );
-                        
+                        let entries =
+                            std::slice::from_raw_parts((*table).table.as_ptr(), num_entries);
+
                         for entry in entries {
                             let local_port = u16::from_be(entry.dwLocalPort as u16);
                             if local_port == port {
@@ -771,7 +771,7 @@ impl FirewallEngine {
                     windows::Win32::NetworkManagement::IpHelper::UDP_TABLE_OWNER_PID,
                     0,
                 );
-                
+
                 if size > 0 {
                     let mut buffer = vec![0u8; size as usize];
                     if windows::Win32::NetworkManagement::IpHelper::GetExtendedUdpTable(
@@ -781,14 +781,13 @@ impl FirewallEngine {
                         windows::Win32::Networking::WinSock::AF_INET.0 as u32,
                         windows::Win32::NetworkManagement::IpHelper::UDP_TABLE_OWNER_PID,
                         0,
-                    ) == 0 {
+                    ) == 0
+                    {
                         let table = buffer.as_ptr() as *const windows::Win32::NetworkManagement::IpHelper::MIB_UDPTABLE_OWNER_PID;
                         let num_entries = (*table).dwNumEntries as usize;
-                        let entries = std::slice::from_raw_parts(
-                            (*table).table.as_ptr(),
-                            num_entries,
-                        );
-                        
+                        let entries =
+                            std::slice::from_raw_parts((*table).table.as_ptr(), num_entries);
+
                         for entry in entries {
                             let local_port = u16::from_be(entry.dwLocalPort as u16);
                             if local_port == port {
@@ -1008,26 +1007,48 @@ impl FirewallEngine {
 
                         // 2. Ensure Alert Window is Open
                         if tx_monitor.get_webview_window("firewall-alert").is_none() {
-                             println!("DEBUG: Spawning Firewall Alert Window...");
-                             let _ = WebviewWindowBuilder::new(
+                            println!("DEBUG: Spawning Firewall Alert Window...");
+
+                            let toast_size = PhysicalSize::new(420.0, 260.0);
+                            let position =
+                                tx_monitor
+                                    .primary_monitor()
+                                    .ok()
+                                    .flatten()
+                                    .and_then(|monitor| {
+                                        let scale = monitor.scale_factor();
+                                        let size = monitor.size();
+
+                                        let x = size.width as f64 / scale - toast_size.width - 24.0;
+                                        let y =
+                                            size.height as f64 / scale - toast_size.height - 24.0;
+
+                                        Some(Position::Physical(PhysicalPosition::new(x, y)))
+                                    });
+
+                            let mut builder = WebviewWindowBuilder::new(
                                 &tx_monitor,
                                 "firewall-alert",
-                                WebviewUrl::App("index.html?mode=alert".into())
+                                WebviewUrl::App("index.html?mode=alert".into()),
                             )
-                             .title("Firewall Alert")
-                             .inner_size(400.0, 320.0)
-                             .resizable(false)
-                             .always_on_top(true)
-                             .decorations(false)
-                             .center()
-                             .skip_taskbar(false)
-                             .build();
-                        } else {
-                            if let Some(win) = tx_monitor.get_webview_window("firewall-alert") {
-                                let _ = win.unminimize();
-                                let _ = win.show();
-                                let _ = win.set_focus();
+                            .title("Firewall Alert")
+                            .inner_size(toast_size.width, toast_size.height)
+                            .resizable(false)
+                            .always_on_top(true)
+                            .decorations(false)
+                            .skip_taskbar(true);
+
+                            if let Some(pos) = position {
+                                builder = builder.position(pos);
+                            } else {
+                                builder = builder.center();
                             }
+
+                            let _ = builder.build();
+                        } else if let Some(win) = tx_monitor.get_webview_window("firewall-alert") {
+                            let _ = win.unminimize();
+                            let _ = win.show();
+                            let _ = win.set_focus();
                         }
 
                         // Don't spam the UI, wait for user validation interaction
@@ -1036,15 +1057,15 @@ impl FirewallEngine {
                         // If no pending app, we might want to close the alert window?
                         // Actually, if we resolved it, the window might stay open showing "Waiting..." or empty.
                         // Ideally, we close it from the UI side when decision is made.
-                        
+
                         // Check if we should auto-close empty prompt window?
                         // For now, let the user close it or the UI logic handle it.
                         // UI logic: resolve_decision calls invoke -> updates state -> PendingApp becomes None.
                         // If PendingApp is None, the UI shows "Waiting..."
-                        
+
                         // We can optionally hide the window if no pending app?
                         // But let's leave valid "Waiting" state for now.
-                        
+
                         std::thread::sleep(Duration::from_millis(200));
                     }
                 }
@@ -1058,7 +1079,7 @@ impl FirewallEngine {
             .name("global_injector".to_string())
             .spawn(move || {
                 use windows::Win32::System::Diagnostics::ToolHelp::{
-                    CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+                    CreateToolhelp32Snapshot, PROCESSENTRY32W, Process32FirstW, Process32NextW,
                     TH32CS_SNAPPROCESS,
                 };
 
@@ -1081,17 +1102,25 @@ impl FirewallEngine {
                                             // More aggressive: Only skip IDLE and SYSTEM
                                             if pid != 0 && pid != 4 && pid != std::process::id() {
                                                 let already_tracked = {
-                                                    let injected = am_global.injected_pids.read().unwrap();
+                                                    let injected =
+                                                        am_global.injected_pids.read().unwrap();
                                                     injected.contains(&pid)
                                                 };
 
-                                                if !already_tracked || !Injector::is_dll_loaded(pid, "hook_dll.dll") {
+                                                if !already_tracked
+                                                    || !Injector::is_dll_loaded(pid, "hook_dll.dll")
+                                                {
                                                     // Robust check: Is the DLL actually in the process?
                                                     // (Even if we didn't inject it this session or it failed before)
-                                                    let (_info_name, info_path) = Injector::get_process_info(pid);
+                                                    let (_info_name, info_path) =
+                                                        Injector::get_process_info(pid);
                                                     if !Injector::is_path_excluded(&info_path) {
-                                                        if Injector::inject(pid, &hook_dll).is_ok() {
-                                                            let mut injected = am_global.injected_pids.write().unwrap();
+                                                        if Injector::inject(pid, &hook_dll).is_ok()
+                                                        {
+                                                            let mut injected = am_global
+                                                                .injected_pids
+                                                                .write()
+                                                                .unwrap();
                                                             injected.insert(pid);
                                                         }
                                                     }
@@ -1152,20 +1181,28 @@ impl FirewallEngine {
                                 // 1. Try native Windows TCP/UDP table lookup (most reliable)
                                 // 2. Fallback to hook DLL port mapping
                                 let mut pid = 0u32;
-                                if let Some(p_info) = Self::parse_packet(&packet.data, outbound, 0, &am_w.info_cache) {
-                                    let lookup_port = if outbound { p_info.src_port } else { p_info.dst_port };
-                                    let is_tcp = matches!(p_info.protocol, crate::engine::Protocol::TCP);
-                                    
+                                if let Some(p_info) =
+                                    Self::parse_packet(&packet.data, outbound, 0, &am_w.info_cache)
+                                {
+                                    let lookup_port = if outbound {
+                                        p_info.src_port
+                                    } else {
+                                        p_info.dst_port
+                                    };
+                                    let is_tcp =
+                                        matches!(p_info.protocol, crate::engine::Protocol::TCP);
+
                                     // Primary: Native Windows API lookup
                                     pid = Self::resolve_pid_from_port(lookup_port, is_tcp);
-                                    
+
                                     // Fallback: Hook DLL mapping (if native lookup failed)
                                     if pid == 0 {
-                                        if let Some(mapped_pid) = am_w.get_pid_for_port(lookup_port) {
+                                        if let Some(mapped_pid) = am_w.get_pid_for_port(lookup_port)
+                                        {
                                             pid = mapped_pid;
                                         }
                                     }
-                                    
+
                                     // Cache the resolved port->PID mapping for future
                                     if pid != 0 {
                                         am_w.update_port_mapping(lookup_port, pid);
@@ -1189,16 +1226,26 @@ impl FirewallEngine {
                                 );
 
                                 // EMIT RAW PACKET FOR UI (Wireshark-like view)
-                                if let Some(info) = Self::parse_packet(&decision.packet_data, outbound, pid, &am_w.info_cache) {
+                                if let Some(info) = Self::parse_packet(
+                                    &decision.packet_data,
+                                    outbound,
+                                    pid,
+                                    &am_w.info_cache,
+                                ) {
                                     let ts = Self::now_ts();
                                     let app_info = am_w.info_cache.get_info(pid);
-                                    
+
                                     let payload_preview = if decision.packet_data.len() > 32 {
-                                        format!("{}...", String::from_utf8_lossy(&decision.packet_data[..32]).replace("\n", " "))
+                                        format!(
+                                            "{}...",
+                                            String::from_utf8_lossy(&decision.packet_data[..32])
+                                                .replace("\n", " ")
+                                        )
                                     } else {
-                                        String::from_utf8_lossy(&decision.packet_data).replace("\n", " ")
+                                        String::from_utf8_lossy(&decision.packet_data)
+                                            .replace("\n", " ")
                                     };
-                                    
+
                                     let raw_packet = crate::sdk::RawPacket {
                                         id: format!("{}-{}-{}", ts, info.src_port, info.dst_port),
                                         timestamp: ts,
@@ -1208,13 +1255,22 @@ impl FirewallEngine {
                                         dst_port: info.dst_port,
                                         protocol: info.protocol.clone(),
                                         length: decision.packet_data.len(),
-                                        payload_hex: decision.packet_data.iter().map(|b| format!("{:02X}", b)).collect::<Vec<_>>().join(" "),
+                                        payload_hex: decision
+                                            .packet_data
+                                            .iter()
+                                            .map(|b| format!("{:02X}", b))
+                                            .collect::<Vec<_>>()
+                                            .join(" "),
                                         payload_preview,
                                         summary: format!("{} -> {}", info.src_ip, info.dst_ip),
                                         process_id: pid,
                                         process_name: app_info.name,
                                         process_path: app_info.path,
-                                        action: if decision.should_forward { "Allow".to_string() } else { "Block".to_string() },
+                                        action: if decision.should_forward {
+                                            "Allow".to_string()
+                                        } else {
+                                            "Block".to_string()
+                                        },
                                         rule: decision._reason.clone(),
                                     };
                                     let _ = tx_log.emit("raw_packet", raw_packet);
@@ -1270,7 +1326,11 @@ impl FirewallEngine {
         // 1. Resolve PID via port mapping if missing (0)
         if pid == 0 {
             if let Some(temp_info) = Self::parse_packet(&data_vec, outbound, 0, &am.info_cache) {
-                let lookup_port = if outbound { temp_info.src_port } else { temp_info.dst_port };
+                let lookup_port = if outbound {
+                    temp_info.src_port
+                } else {
+                    temp_info.dst_port
+                };
                 if let Some(mapped_pid) = am.get_pid_for_port(lookup_port) {
                     pid = mapped_pid;
                 }
@@ -1294,7 +1354,9 @@ impl FirewallEngine {
             let sdk_read = sdk.read().unwrap();
             for changer in &sdk_read.changers {
                 if changer.modify(&mut data_vec, &info, &sdk_context) {
-                    if let Some(new_info) = Self::parse_packet(&data_vec, outbound, pid, &am.info_cache) {
+                    if let Some(new_info) =
+                        Self::parse_packet(&data_vec, outbound, pid, &am.info_cache)
+                    {
                         info = new_info;
                     }
                 }
@@ -1325,12 +1387,13 @@ impl FirewallEngine {
             // File Magic Detection
             let detected_type = file_checker.check(&data_vec);
             if let Some(ref dtype) = detected_type {
-                 // Reuse info struct? No, it's owned now. We modify the copy or just cache it?
-                 // 'info' is local.
-                 am.url_cache.write().unwrap().insert(pid, format!("FILESIG:{}", dtype));
-                 info.detected_file_type = Some(dtype.clone());
-                 
-
+                // Reuse info struct? No, it's owned now. We modify the copy or just cache it?
+                // 'info' is local.
+                am.url_cache
+                    .write()
+                    .unwrap()
+                    .insert(pid, format!("FILESIG:{}", dtype));
+                info.detected_file_type = Some(dtype.clone());
             }
 
             let (auto_inject_https, hook_dll) = {
@@ -1346,7 +1409,7 @@ impl FirewallEngine {
             {
                 let mut injected = am.injected_pids.write().unwrap();
                 let mut failed = am.failed_pids.write().unwrap();
-                
+
                 if !injected.contains(&info.process_id) && !failed.contains(&info.process_id) {
                     match Injector::inject(info.process_id, &hook_dll) {
                         Ok(()) => {
@@ -1656,7 +1719,12 @@ impl FirewallEngine {
         (urls, domains)
     }
 
-    fn parse_packet(data: &[u8], outbound: bool, process_id: u32, cache: &AppInfoCache) -> Option<PacketInfo> {
+    fn parse_packet(
+        data: &[u8],
+        outbound: bool,
+        process_id: u32,
+        cache: &AppInfoCache,
+    ) -> Option<PacketInfo> {
         if data.len() < 20 {
             return None;
         }
@@ -1675,7 +1743,6 @@ impl FirewallEngine {
         let src_ip = Ipv4Addr::new(data[12], data[13], data[14], data[15]);
         let dst_ip = Ipv4Addr::new(data[16], data[17], data[18], data[19]);
         let header_len = ((data[0] & 0x0F) as usize) * 4;
-        
 
         let (src_port, dst_port) = if header_len + 4 <= data.len() {
             match protocol {

--- a/HydraDragonFirewall/hydradragonfirewall/ui/style.css
+++ b/HydraDragonFirewall/hydradragonfirewall/ui/style.css
@@ -386,6 +386,13 @@ main {
     /* Active: allow clicks when open */
 }
 
+.modal-overlay.static-mode {
+    background: transparent;
+    align-items: flex-end;
+    justify-content: flex-end;
+    padding: 16px;
+}
+
 .glass-modal {
     width: 450px;
     background: #121419;
@@ -395,6 +402,14 @@ main {
     position: relative;
     z-index: 2001;
     /* Above overlay */
+}
+
+.modal-overlay.static-mode .glass-modal {
+    width: 360px;
+    padding: 24px;
+    border-radius: 16px;
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.45);
+    pointer-events: auto;
 }
 
 .input-group {


### PR DESCRIPTION
## Summary
- position the firewall alert window near the bottom-right of the primary display, skipping the taskbar to mimic a lightweight toast
- fall back to centered placement if display metrics are unavailable and keep alert visibility by restoring existing windows
- add compact styling for alert-mode overlays so prompts resemble Windows-style notifications

## Testing
- cargo fmt
- cargo check *(fails: missing system library `glib-2.0` required by `glib-sys` in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69542324c444832aada83f283464779a)

## Summary by Sourcery

Position the firewall alert window as a toast-style notification and adjust UI styling to support compact, bottom-right alerts.

Enhancements:
- Show the firewall alert window near the bottom-right of the primary monitor with taskbar-aware positioning and fall back to centered placement when monitor metrics are unavailable.
- Update alert window behavior to reuse and refocus an existing alert window instead of redundantly rebuilding it when already open.
- Introduce a compact, toast-style variant of the modal overlay and glass modal for alert mode, with transparent overlay, bottom-right alignment, and reduced sizing.
- Apply minor formatting and readability improvements across the firewall engine code without changing behavior.