### PR TITLE
fix(OpenEDR): quarantine files with flsVerdict:2 from processes[] and childProcess events

### DIFF
--- a/OpenEDR/owlyshield_predict/src/behavioral/behavior_engine.rs
+++ b/OpenEDR/owlyshield_predict/src/behavioral/behavior_engine.rs
@@ -3710,14 +3710,80 @@ impl BehaviorEngine {
             }
         }
 
-        let event_type = str_at(event, &["type"])
+        // Resolve event_type — some events use numeric `baseEventType` instead
+        // of a string `type` field, so we convert the number to a synthetic tag.
+        let event_type_owned: String;
+        let event_type = match str_at(event, &["type"])
             .or_else(|| str_at(event, &["event_type"]))
             .or_else(|| str_at(event, &["baseType"]))
-            .unwrap_or("")
-            .trim();
+        {
+            Some(t) => t.trim(),
+            None => {
+                event_type_owned = u64_at(event, &["baseEventType"])
+                    .map(|code| format!("BASE_EVENT_{code}"))
+                    .unwrap_or_default();
+                event_type_owned.as_str()
+            }
+        };
+
+        // --- Nested verdict scan (processes[] / childProcess) ----------------
+        // MLE_INTEGRITY_LEVEL_ELEVATION and child-process creation events carry
+        // flsVerdict inside `processes[]` items and/or a `childProcess` object
+        // rather than at the top level. We must scan these **before** the
+        // pid == 0 early-return guard, because these events often lack a
+        // top-level PID.
+        if let Some(processes) = event.get("processes").and_then(|v| v.as_array()) {
+            for proc in processes {
+                let verdict = proc
+                    .get("flsVerdict")
+                    .or_else(|| proc.get("verdict"))
+                    .and_then(OpenEdrFlsVerdict::from_json_value);
+                if verdict.is_some_and(OpenEdrFlsVerdict::is_malicious) {
+                    if let Some(path) = proc.get("imagePath").and_then(|v| v.as_str()).filter(|p| !p.is_empty()) {
+                        Logging::warning(&format!(
+                            "[OpenEDRVerdict] Malicious flsVerdict in processes[] for {}",
+                            path
+                        ));
+                        Self::quarantine_verdict_file(
+                            path,
+                            &format!("OpenEDR nested process verdict (FLS): Malware"),
+                        );
+                    }
+                }
+            }
+        }
+
+        if let Some(child) = event.get("childProcess") {
+            let verdict = child
+                .get("flsVerdict")
+                .or_else(|| child.get("verdict"))
+                .and_then(OpenEdrFlsVerdict::from_json_value);
+            if verdict.is_some_and(OpenEdrFlsVerdict::is_malicious) {
+                if let Some(path) = child.get("imagePath").and_then(|v| v.as_str()).filter(|p| !p.is_empty()) {
+                    Logging::warning(&format!(
+                        "[OpenEDRVerdict] Malicious flsVerdict in childProcess for {}",
+                        path
+                    ));
+                    Self::quarantine_verdict_file(
+                        path,
+                        &format!("OpenEDR childProcess verdict (FLS): Malware"),
+                    );
+                }
+            }
+        }
+
+        // PID resolution — also try extracting from childProcess or first
+        // entry of the processes array as a fallback.
         let pid = u64_at(event, &["process", "pid"])
             .or_else(|| u64_at(event, &["process.pid"]))
             .or_else(|| u64_at(event, &["pid"]))
+            .or_else(|| u64_at(event, &["childProcess", "pid"]))
+            .or_else(|| {
+                event.get("processes")
+                    .and_then(|v| v.as_array())
+                    .and_then(|arr| arr.last())
+                    .and_then(|p| u64_at(p, &["pid"]))
+            })
             .unwrap_or(0)
             .min(u32::MAX as u64) as u32;
         if pid == 0 || event_type.is_empty() {


### PR DESCRIPTION
## Summary

OpenEDR correctly detects malicious files with `flsVerdict: 2` in `MLE_INTEGRITY_LEVEL_ELEVATION` and child-process creation events, but **fails to quarantine them**. The file should be moved to `C:\ProgramData\HydraDragonQuarantine` and sealed into a XOR-encrypted `.hqf` container via `owlyshield_ransom.dll`, but this never happens.

## Root Cause

Three issues in `ingest_openedr_event()` inside [behavior_engine.rs](OpenEDR/owlyshield_predict/src/behavioral/behavior_engine.rs):

### 1. `processes[]` and `childProcess` never scanned
The code only checks **top-level** `flsVerdict` / `verdict` fields. But `MLE_INTEGRITY_LEVEL_ELEVATION` events carry the verdict **inside** `processes[]` array items and `childProcess` objects — these were silently ignored.

### 2. `pid == 0` guard drops the entire event
These event types don't carry a top-level `pid` field (PID is only inside `processes[].pid` or `childProcess.pid`). The `pid == 0` early-return guard was dropping the entire event before any quarantine logic could run.

### 3. `baseEventType` (numeric) not resolved
Some events use `"baseEventType": 1` (numeric) instead of a string `"type"` field. The `str_at()` parser couldn't resolve it, causing `event_type == ""` and another early return.

## Changes

All changes are in `OpenEDR/owlyshield_predict/src/behavioral/behavior_engine.rs`:

- **Added `processes[]` array scanning**: Iterates all entries, quarantines any with `flsVerdict: 2`
- **Added `childProcess` object scanning**: Same logic for the `childProcess` field
- **Moved nested scans before the `pid == 0` guard**: So events without a top-level PID still trigger quarantine
- **Extended PID resolution**: Falls back to `childProcess.pid` and `processes[].pid`
- **Added `baseEventType` numeric support**: Converts `"baseEventType": 1` to `"BASE_EVENT_1"` string

## Testing

- `cargo check --package owlyshield_ransom` passes with 0 errors (5 pre-existing dead_code warnings, unrelated)
- Manual verification needed: run a `flsVerdict: 2` sample in a test VM and confirm `.hqf` file appears in `C:\ProgramData\HydraDragonQuarantine`
