### PR TITLE
Fix OpenEDR Quarantine and Owlyshield Log Forwarding

### DIFF
--- a/OpenEDR/edrav2/iprj/libcloud/src/fls.cpp
+++ b/OpenEDR/edrav2/iprj/libcloud/src/fls.cpp
@@ -703,13 +703,13 @@ void FlsService::enrichFileVerdict(Variant vFile)
 				}
 				else
 				{
-					LOGWRN("Failed to locate owlyshield_dll_quarantine_file in loaded DLL");
+					LOGLVL(Critical, "Failed to locate owlyshield_dll_quarantine_file in loaded DLL");
 				}
 				::FreeLibrary(hDll);
 			}
 			else
 			{
-				LOGWRN("Failed to load owlyshield_ransom.dll for dynamic quarantine");
+				LOGLVL(Critical, "Failed to load owlyshield_ransom.dll for dynamic quarantine");
 			}
 		}
 	}

--- a/OpenEDR/edrav2/iprj/libcloud/src/fls.cpp
+++ b/OpenEDR/edrav2/iprj/libcloud/src/fls.cpp
@@ -687,7 +687,7 @@ void FlsService::enrichFileVerdict(Variant vFile)
 		std::string sFilePath = vFile["path"];
 		if (!sFilePath.empty())
 		{
-			LOGLVL(Info, "FLS Verdict is Malicious! Dynamically invoking Owlyshield Quarantine for: <" << sFilePath << ">");
+			LOGLVL(Detailed, "FLS Verdict is Malicious! Dynamically invoking Owlyshield Quarantine for: <" << sFilePath << ">");
 			HMODULE hDll = ::LoadLibraryW(L"owlyshield_ransom.dll");
 			if (hDll != nullptr)
 			{
@@ -699,17 +699,17 @@ void FlsService::enrichFileVerdict(Variant vFile)
 						reinterpret_cast<const uint8_t*>(sFilePath.data()),
 						static_cast<uint32_t>(sFilePath.size())
 					);
-					LOGLVL(Info, "Owlyshield Quarantine executed for <" << sFilePath << "> with result: " << qRes);
+					LOGLVL(Detailed, "Owlyshield Quarantine executed for <" << sFilePath << "> with result: " << qRes);
 				}
 				else
 				{
-					LOGLVL(Warning, "Failed to locate owlyshield_dll_quarantine_file in loaded DLL");
+					LOGLVL(Error, "Failed to locate owlyshield_dll_quarantine_file in loaded DLL");
 				}
 				::FreeLibrary(hDll);
 			}
 			else
 			{
-				LOGLVL(Warning, "Failed to load owlyshield_ransom.dll for dynamic quarantine");
+				LOGLVL(Error, "Failed to load owlyshield_ransom.dll for dynamic quarantine");
 			}
 		}
 	}

--- a/OpenEDR/edrav2/iprj/libcloud/src/fls.cpp
+++ b/OpenEDR/edrav2/iprj/libcloud/src/fls.cpp
@@ -687,7 +687,7 @@ void FlsService::enrichFileVerdict(Variant vFile)
 		std::string sFilePath = vFile["path"];
 		if (!sFilePath.empty())
 		{
-			LOGLVL(Detailed, "FLS Verdict is Malicious! Dynamically invoking Owlyshield Quarantine for: <" << sFilePath << ">");
+			LOGLVL(Normal, "FLS Verdict is Malicious! Dynamically invoking Owlyshield Quarantine for: <" << sFilePath << ">");
 			HMODULE hDll = ::LoadLibraryW(L"owlyshield_ransom.dll");
 			if (hDll != nullptr)
 			{
@@ -699,17 +699,17 @@ void FlsService::enrichFileVerdict(Variant vFile)
 						reinterpret_cast<const uint8_t*>(sFilePath.data()),
 						static_cast<uint32_t>(sFilePath.size())
 					);
-					LOGLVL(Detailed, "Owlyshield Quarantine executed for <" << sFilePath << "> with result: " << qRes);
+					LOGLVL(Normal, "Owlyshield Quarantine executed for <" << sFilePath << "> with result: " << qRes);
 				}
 				else
 				{
-					LOGLVL(Error, "Failed to locate owlyshield_dll_quarantine_file in loaded DLL");
+					LOGWRN("Failed to locate owlyshield_dll_quarantine_file in loaded DLL");
 				}
 				::FreeLibrary(hDll);
 			}
 			else
 			{
-				LOGLVL(Error, "Failed to load owlyshield_ransom.dll for dynamic quarantine");
+				LOGWRN("Failed to load owlyshield_ransom.dll for dynamic quarantine");
 			}
 		}
 	}

--- a/OpenEDR/edrav2/iprj/libcloud/src/fls.cpp
+++ b/OpenEDR/edrav2/iprj/libcloud/src/fls.cpp
@@ -682,6 +682,38 @@ void FlsService::enrichFileVerdict(Variant vFile)
 	auto verdict = getFileVerdict(sFileHash);
 	putByPath(vFile, "fls.verdict", verdict, true /* fCreatePaths */);
 
+	if (verdict == FileVerdict::Malicious)
+	{
+		std::string sFilePath = vFile["path"];
+		if (!sFilePath.empty())
+		{
+			LOGLVL(Info, "FLS Verdict is Malicious! Dynamically invoking Owlyshield Quarantine for: <" << sFilePath << ">");
+			HMODULE hDll = ::LoadLibraryW(L"owlyshield_ransom.dll");
+			if (hDll != nullptr)
+			{
+				typedef int32_t (*OwlyshieldDllQuarantineFileFn)(const uint8_t*, uint32_t);
+				auto fnQuarantine = (OwlyshieldDllQuarantineFileFn)::GetProcAddress(hDll, "owlyshield_dll_quarantine_file");
+				if (fnQuarantine != nullptr)
+				{
+					int32_t qRes = fnQuarantine(
+						reinterpret_cast<const uint8_t*>(sFilePath.data()),
+						static_cast<uint32_t>(sFilePath.size())
+					);
+					LOGLVL(Info, "Owlyshield Quarantine executed for <" << sFilePath << "> with result: " << qRes);
+				}
+				else
+				{
+					LOGLVL(Warning, "Failed to locate owlyshield_dll_quarantine_file in loaded DLL");
+				}
+				::FreeLibrary(hDll);
+			}
+			else
+			{
+				LOGLVL(Warning, "Failed to load owlyshield_ransom.dll for dynamic quarantine");
+			}
+		}
+	}
+
 	auto optItem = m_pFileVerdictProvider->getCacheItem(sFileHash);
 	if (optItem.has_value())
 	{

--- a/OpenEDR/owlyshield_predict/src/actions_on_kill.rs
+++ b/OpenEDR/owlyshield_predict/src/actions_on_kill.rs
@@ -374,6 +374,7 @@ impl ActionsOnKill {
                 Box::new(WriteReportFile()),
                 Box::new(Connectors),
                 Box::new(Logging),
+                Box::new(WriteOpenEdrEventLog()),
             ],
         }
     }
@@ -390,6 +391,7 @@ impl ActionsOnKill {
                 Box::new(WriteReportFile()),
                 Box::new(Connectors),
                 Box::new(Logging),
+                Box::new(WriteOpenEdrEventLog()),
             ],
         }
     }
@@ -543,6 +545,85 @@ impl ActionOnKill for WriteReportFile {
         for f in &proc.fpaths_updated {
             file.write_all(format!("\t{f:?}\n").as_bytes())?;
         }
+        Ok(())
+    }
+}
+
+pub struct WriteOpenEdrEventLog();
+
+impl ActionOnKill for WriteOpenEdrEventLog {
+    fn run(
+        &self,
+        _config: &Config,
+        proc: &mut ProcessRecord,
+        _pred_mtrx: &VecvecCappedF32,
+        threat_info: &ThreatInfo,
+        _report_context: &ActionReportContext,
+        _now: &str,
+    ) -> Result<(), Box<dyn Error>> {
+        if !threat_info.should_notify() {
+            return Ok(());
+        }
+
+        // Determine output directory: place in same output_events folder OpenEDR uses.
+        let log_path_val = crate::config::ConfigReader::read_param_from_registry("LOG_PATH", r"SOFTWARE\Owlyshield");
+        let log_dir = if !log_path_val.trim().is_empty() {
+            PathBuf::from(log_path_val)
+        } else if let Some(program_data) = std::env::var_os("ProgramData") {
+            PathBuf::from(program_data).join("edrsvc").join("log")
+        } else {
+            std::env::temp_dir().join("owlyshield")
+        };
+
+        // Go up one level from 'owlyshield' subdirectory to get the main 'log' folder if needed
+        let mut base_log_dir = log_dir.clone();
+        if base_log_dir.file_name().and_then(|n| n.to_str()).map_or(false, |s| s.eq_ignore_ascii_case("owlyshield")) {
+            base_log_dir.pop();
+        }
+
+        let output_events_dir = base_log_dir.join("output_events");
+        std::fs::create_dir_all(&output_events_dir)?;
+
+        // Daily file name: owlyshield_YYYYMMDD.log
+        let today = chrono::Local::now().format("%Y%m%d").to_string();
+        let log_file_path = output_events_dir.join(format!("owlyshield_{}.log", today));
+
+        // Create the JSON event matching OpenEDR format
+        let event_time_iso = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+
+        let event = serde_json::json!({
+            "customerId": crate::config::ConfigReader::read_param_from_registry("CUSTOMER_ID", r"SOFTWARE\Owlyshield"),
+            "endpointId": crate::config::ConfigReader::read_param_from_registry("ENDPOINT_ID", r"SOFTWARE\Owlyshield"),
+            "eventGroup": "THREAT",
+            "eventType": "BEHAVIORAL_ALERT",
+            "eventTime": event_time_iso,
+            "status": "ALERT",
+            "threat": {
+                "type": threat_info.threat_type_label,
+                "name": threat_info.virus_name,
+                "certainty": threat_info.prediction,
+                "matchDetails": threat_info.match_details,
+                "response": threat_info.response_label_for(proc),
+                "remediation": proc.primary_remediation_path().to_string_lossy()
+            },
+            "process": {
+                "processId": proc.pids.iter().next().copied().unwrap_or(0),
+                "processPath": proc.exepath.to_string_lossy(),
+                "processName": proc.appname,
+                "processGroupId": proc.gid
+            },
+            "filesModified": proc.fpaths_updated.iter().collect::<Vec<&String>>()
+        });
+
+        // Open file in append mode
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_file_path)?;
+
+        let json_line = serde_json::to_string(&event)?;
+        writeln!(file, "{}", json_line)?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
This pull request resolves the integration issues between OpenEDR and Owlyshield:
- Resolves the quarantine problem by dynamically loading the Owlyshield DLL (`owlyshield_ransom.dll`) and invoking its quarantine function when OpenEDR FLS returns a Malicious file verdict.
- Establishes a seamless log-forwarding pipeline by writing behavioral threat events directly into OpenEDR's JSON event output folder (`output_events`), enabling native Filebeat ingestion and processing.

---
*PR created automatically by Jules for task [14630421559415862939](https://jules.google.com/task/14630421559415862939) started by @Siradankullanici*