### PR TITLE
Gracefully serialize non-serializable ValueType::Object in Variant to prevent telemetry event drops

### DIFF
--- a/OpenEDR/edrav2/iprj/libcore/src/serialize_variant.cpp
+++ b/OpenEDR/edrav2/iprj/libcore/src/serialize_variant.cpp
@@ -168,7 +168,17 @@ nljson saveVariantToJson(const cmd::Variant& vElement)
 		}
 		case ValueType::Object:
 		{
-			return saveVariantToJson(serializeObject(vElement));
+			try
+			{
+				return saveVariantToJson(serializeObject(vElement));
+			}
+			catch (...)
+			{
+				ObjPtr<IObject> pObj = vElement;
+				if (pObj == nullptr)
+					return nljson(nljson::value_t::null);
+				return nljson(string::convertToHex(pObj->getClassId()));
+			}
 		}
 	}
 	error::TypeError(SL, "Unsupported element type in Variant").throwException();
@@ -347,7 +357,17 @@ Json::Value saveVariantToJson(const cmd::Variant& vValue)
 		}
 		case ValueType::Object:
 		{
-			return saveVariantToJson(serializeObject(vValue));
+			try
+			{
+				return saveVariantToJson(serializeObject(vValue));
+			}
+			catch (...)
+			{
+				ObjPtr<IObject> pObj = vValue;
+				if (pObj == nullptr)
+					return {};
+				return Json::Value(string::convertToHex(pObj->getClassId()));
+			}
 		}
 	}
 	error::TypeError(SL, "Unsupported element type in Variant").throwException();


### PR DESCRIPTION
This change fixes a critical bug where OpenEDR telemetry events enriched with process/file/registry metadata were being silently discarded. This occurred because the process dictionary contains `token.tokenObj`, which is a C++ `IToken` object pointer (represented as `ValueType::Object`). When the JSON serializer attempted to serialize this object, it threw a `TypeError` as it did not implement `ISerializable` or `IReadableStream`. The try-catch block in `sendEnrichedTelemetryToOwlyshield` would then silently drop the entire event.

We fixed this by wrapping the `serializeObject` calls in `json_nlohmann::saveVariantToJson` and `json_jsoncpp::saveVariantToJson` with try-catch blocks that gracefully fall back to returning the hexadecimal Class ID string of the object. This prevents serialization failure and ensures that telemetry events are successfully transmitted.

---
*PR created automatically by Jules for task [5479823007178788853](https://jules.google.com/task/5479823007178788853) started by @Siradankullanici*