### PR TITLE
Keep all rules enabled in convert_emerging_rules.py and emerging-all.yaml

### DIFF
--- a/OpenEDR/edrav2/firewall-rules/emerging-all.yaml
+++ b/OpenEDR/edrav2/firewall-rules/emerging-all.yaml
@@ -15,8 +15,7 @@ rules:
       case_insensitive: false
   - name: "sid:2009285"
     description: "ET SHELLCODE Bindshell2 Decoder Shellcode (UDP)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -24,8 +23,7 @@ rules:
       case_insensitive: false
   - name: "sid:2009247"
     description: "ET SHELLCODE Rothenburg Shellcode"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -35,8 +33,7 @@ rules:
       established: true
   - name: "sid:2006417"
     description: "ET ATTACK_RESPONSE Weak Netbios Lanman Auth Challenge Detected"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -47,8 +44,7 @@ rules:
       case_insensitive: false
   - name: "sid:2008690"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (1)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -59,8 +55,7 @@ rules:
       case_insensitive: false
   - name: "sid:2008691"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (2)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -71,8 +66,7 @@ rules:
       case_insensitive: false
   - name: "sid:2008692"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (3)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -83,8 +77,7 @@ rules:
       case_insensitive: false
   - name: "sid:2008693"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (4)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -95,8 +88,7 @@ rules:
       case_insensitive: false
   - name: "sid:2008694"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (5)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -107,8 +99,7 @@ rules:
       case_insensitive: false
   - name: "sid:2008696"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (7)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -119,8 +110,7 @@ rules:
       case_insensitive: false
   - name: "sid:2008697"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (8)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -131,8 +121,7 @@ rules:
       case_insensitive: false
   - name: "sid:2008698"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (9)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -143,8 +132,7 @@ rules:
       case_insensitive: false
   - name: "sid:2008699"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (10)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -155,8 +143,7 @@ rules:
       case_insensitive: false
   - name: "sid:2008700"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 - Known Exploit Instance"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -167,8 +154,7 @@ rules:
       case_insensitive: false
   - name: "sid:2008701"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (11)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -182,8 +168,7 @@ rules:
       to_server: true
   - name: "sid:2008702"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (12)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -197,8 +182,7 @@ rules:
       to_server: true
   - name: "sid:2008703"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (13)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -212,8 +196,7 @@ rules:
       to_server: true
   - name: "sid:2008704"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (14)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -227,8 +210,7 @@ rules:
       to_server: true
   - name: "sid:2008705"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (15)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -242,8 +224,7 @@ rules:
       to_server: true
   - name: "sid:2008706"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (16)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -257,8 +238,7 @@ rules:
       to_server: true
   - name: "sid:2008707"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (17)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -272,8 +252,7 @@ rules:
       to_server: true
   - name: "sid:2008708"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (18)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -287,8 +266,7 @@ rules:
       to_server: true
   - name: "sid:2008709"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (19)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -302,8 +280,7 @@ rules:
       to_server: true
   - name: "sid:2008710"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (20)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -317,8 +294,7 @@ rules:
       to_server: true
   - name: "sid:2008712"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (22)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -332,8 +308,7 @@ rules:
       to_server: true
   - name: "sid:2008713"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (23)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -347,8 +322,7 @@ rules:
       to_server: true
   - name: "sid:2008714"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (24)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -362,8 +336,7 @@ rules:
       to_server: true
   - name: "sid:2008715"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (25)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -377,8 +350,7 @@ rules:
       to_server: true
   - name: "sid:2008717"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (27)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -392,8 +364,7 @@ rules:
       to_server: true
   - name: "sid:2008718"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (28)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -407,8 +378,7 @@ rules:
       to_server: true
   - name: "sid:2008719"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (29)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -422,8 +392,7 @@ rules:
       to_server: true
   - name: "sid:2008720"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 (30)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -437,8 +406,7 @@ rules:
       to_server: true
   - name: "sid:2008721"
     description: "ET NETBIOS Microsoft Windows NETAPI Stack Overflow Inbound - MS08-067 - Known Exploit Instance (2)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -463,8 +431,7 @@ rules:
       to_server: true
   - name: "sid:2002154"
     description: "ET GAMES Guild Wars connection"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -494,8 +461,7 @@ rules:
       to_server: true
   - name: "sid:2008591"
     description: "ET P2P Ares Server Connection"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -514,8 +480,7 @@ rules:
       to_server: true
   - name: "sid:2003311"
     description: "ET P2P Edonkey Publicize File ACK"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -531,8 +496,7 @@ rules:
       max: 19
   - name: "sid:2003312"
     description: "ET P2P Edonkey Connect Request"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -548,8 +512,7 @@ rules:
       exact: 25
   - name: "sid:2002760"
     description: "ET P2P GnucDNA UDP Ultrapeer Traffic"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -571,8 +534,7 @@ rules:
       case_insensitive: false
   - name: "sid:2009097"
     description: "ET P2P Manolito Connection (1)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -585,8 +547,7 @@ rules:
       max: 47
   - name: "sid:2009098"
     description: "ET P2P Manolito Ping"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -664,8 +625,7 @@ rules:
       to_server: true
   - name: "sid:2003155"
     description: "ET INFO Microsoft TEREDO IPv6 tunneling"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -972,8 +932,7 @@ rules:
       to_server: true
   - name: "sid:2000575"
     description: "ET SCAN ICMP PING IPTools"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: icmp
     action: traffic_attack
     regex:
@@ -1058,8 +1017,7 @@ rules:
       to_server: true
   - name: "sid:2009201"
     description: "ET MALWARE Conficker.b Shellcode"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -1426,8 +1384,7 @@ rules:
       to_server: true
   - name: "sid:2002976"
     description: "ET MALWARE Banker.Delf Infection - Sending Initial Email to Owner"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -1543,8 +1500,7 @@ rules:
       to_client: true
   - name: "sid:2009832"
     description: "ET SCAN DCERPC rpcmgmt ifids Unauthenticated BIND"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -1569,8 +1525,7 @@ rules:
       to_server: true
   - name: "sid:2011976"
     description: "ET SCADA RealWin SCADA System Buffer Overflow"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -1735,8 +1690,7 @@ rules:
       case_insensitive: false
   - name: "sid:2001298"
     description: "ET P2P eDonkey Server Status Request"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -1790,8 +1744,7 @@ rules:
       established: true
   - name: "sid:2010141"
     description: "ET P2P Vuze BT UDP Connection (2)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -1817,8 +1770,7 @@ rules:
       exact: 80
   - name: "sid:2010143"
     description: "ET P2P Vuze BT UDP Connection (4)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -1831,8 +1783,7 @@ rules:
       max: 299
   - name: "sid:2009968"
     description: "ET P2P eMule KAD Network Connection Request(2)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -1848,8 +1799,7 @@ rules:
       exact: 35
   - name: "sid:2009969"
     description: "ET P2P eMule KAD Network Firewalled Request"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -1865,8 +1815,7 @@ rules:
       exact: 35
   - name: "sid:2009972"
     description: "ET P2P eMule KAD Network Server Status Request"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -1882,8 +1831,7 @@ rules:
       exact: 44
   - name: "sid:2001809"
     description: "ET P2P Limewire P2P UDP Traffic"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -1964,8 +1912,7 @@ rules:
     ip_proto: 41
   - name: "sid:2012143"
     description: "ET WEB_CLIENT Microsoft Windows MPEG Layer-3 Audio Decoder Buffer Overflow"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -2148,8 +2095,7 @@ rules:
       case_insensitive: false
   - name: "sid:2012317"
     description: "ET NETBIOS Microsoft Windows Server 2003 Active Directory Pre-Auth BROWSER ELECTION Heap Overflow Attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -2182,8 +2128,7 @@ rules:
       to_server: true
   - name: "sid:2012078"
     description: "ET INFO Windows-Based OpenSSL Tunnel Outbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -2228,8 +2173,7 @@ rules:
       established: true
   - name: "sid:2102003"
     description: "GPL SQL Slammer Worm propagation attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -2240,8 +2184,7 @@ rules:
       case_insensitive: false
   - name: "sid:2102004"
     description: "GPL WORM Slammer Worm propagation attempt OUTBOUND"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -2252,8 +2195,7 @@ rules:
       case_insensitive: false
   - name: "sid:2102005"
     description: "GPL RPC portmap kcms_server request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -2264,8 +2206,7 @@ rules:
       case_insensitive: false
   - name: "sid:2102015"
     description: "GPL RPC portmap UNSET attempt UDP 111"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -2276,8 +2217,7 @@ rules:
       case_insensitive: false
   - name: "sid:2102017"
     description: "GPL RPC portmap espd request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -2288,8 +2228,7 @@ rules:
       case_insensitive: false
   - name: "sid:2102025"
     description: "GPL RPC yppasswd username overflow attempt UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -2346,8 +2285,7 @@ rules:
       established: true
   - name: "sid:2101950"
     description: "GPL RPC portmap SET attempt UDP 111"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -2358,8 +2296,7 @@ rules:
       case_insensitive: false
   - name: "sid:2101959"
     description: "GPL RPC portmap NFS request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -2370,8 +2307,7 @@ rules:
       case_insensitive: false
   - name: "sid:2101961"
     description: "GPL RPC portmap RQUOTA request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -2382,8 +2318,7 @@ rules:
       case_insensitive: false
   - name: "sid:2101963"
     description: "GPL RPC RQUOTA getquota overflow attempt UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -2401,8 +2336,7 @@ rules:
         no_case: false
   - name: "sid:2101964"
     description: "GPL RPC tooltalk UDP overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -2420,8 +2354,7 @@ rules:
         no_case: false
   - name: "sid:2101923"
     description: "GPL RPC portmap proxy attempt UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -2460,8 +2393,7 @@ rules:
       to_server: true
   - name: "sid:2101907"
     description: "GPL RPC CMSD UDP CMSD_CREATE buffer overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -2479,8 +2411,7 @@ rules:
         no_case: false
   - name: "sid:2101913"
     description: "GPL RPC STATD UDP stat mon_name format string exploit attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -2498,8 +2429,7 @@ rules:
         no_case: false
   - name: "sid:2101915"
     description: "GPL RPC STATD UDP monitor mon_name format string exploit attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -2557,8 +2487,7 @@ rules:
       case_insensitive: false
   - name: "sid:2101894"
     description: "GPL EXPLOIT kadmind buffer overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -2572,8 +2501,7 @@ rules:
       to_server: true
   - name: "sid:2101895"
     description: "GPL EXPLOIT kadmind buffer overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -2587,8 +2515,7 @@ rules:
       to_server: true
   - name: "sid:2101896"
     description: "GPL EXPLOIT kadmind buffer overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -2602,8 +2529,7 @@ rules:
       to_server: true
   - name: "sid:2101897"
     description: "GPL EXPLOIT kadmind buffer overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -2670,8 +2596,7 @@ rules:
       to_server: true
   - name: "sid:2101746"
     description: "GPL RPC portmap cachefsd request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -2682,8 +2607,7 @@ rules:
       case_insensitive: false
   - name: "sid:2101732"
     description: "GPL RPC portmap rwalld request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -2734,8 +2658,7 @@ rules:
       case_insensitive: false
   - name: "sid:2100371"
     description: "GPL ICMP PING Cisco Type.x"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: icmp
     action: traffic_attack
     regex:
@@ -2743,8 +2666,7 @@ rules:
       case_insensitive: false
   - name: "sid:2100483"
     description: "GPL SCAN PING CyberKit 2.2 Windows"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: icmp
     action: traffic_attack
     regex:
@@ -2768,8 +2690,7 @@ rules:
       case_insensitive: false
   - name: "sid:2100374"
     description: "GPL ICMP PING IP NetMonitor Macintosh"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: icmp
     action: traffic_attack
     regex:
@@ -2809,8 +2730,7 @@ rules:
       case_insensitive: false
   - name: "sid:2100380"
     description: "GPL ICMP PING Seer Windows"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: icmp
     action: traffic_attack
     regex:
@@ -2860,16 +2780,14 @@ rules:
       case_insensitive: false
   - name: "sid:2100640"
     description: "GPL SHELLCODE AIX NOOP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:O���O���O���O���)"
       case_insensitive: false
   - name: "sid:2101948"
     description: "GPL DNS zone transfer UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -2891,8 +2809,7 @@ rules:
       case_insensitive: false
   - name: "sid:2101277"
     description: "GPL RPC portmap ypupdated request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -2903,8 +2820,7 @@ rules:
       case_insensitive: false
   - name: "sid:2100252"
     description: "GPL DNS named iquery attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -2989,8 +2905,7 @@ rules:
       case_insensitive: false
   - name: "sid:2102480"
     description: "GPL NETBIOS SMB-DS InitiateSystemShutdown unicode attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3026,8 +2941,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2102481"
     description: "GPL NETBIOS SMB-DS InitiateSystemShutdown unicode little endian attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3063,8 +2977,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2102482"
     description: "GPL NETBIOS SMB-DS InitiateSystemShutdown attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3100,8 +3013,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2102483"
     description: "GPL NETBIOS SMB-DS InitiateSystemShutdown little endian attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3137,8 +3049,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2102472"
     description: "GPL NETBIOS SMB-DS C$ unicode share access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3162,8 +3073,7 @@ rules:
       to_server: true
   - name: "sid:2102473"
     description: "GPL NETBIOS SMB ADMIN$ unicode share access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3187,8 +3097,7 @@ rules:
       to_server: true
   - name: "sid:2102470"
     description: "GPL NETBIOS SMB C$ unicode share access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3212,8 +3121,7 @@ rules:
       to_server: true
   - name: "sid:2102467"
     description: "GPL NETBIOS SMB D$ unicode share access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3237,8 +3145,7 @@ rules:
       to_server: true
   - name: "sid:2102474"
     description: "GPL NETBIOS SMB-DS ADMIN$ share access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3262,8 +3169,7 @@ rules:
       to_server: true
   - name: "sid:2102475"
     description: "GPL NETBIOS SMB-DS ADMIN$ unicode share access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3287,8 +3193,7 @@ rules:
       to_server: true
   - name: "sid:2102471"
     description: "GPL NETBIOS SMB-DS C$ share access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3312,8 +3217,7 @@ rules:
       to_server: true
   - name: "sid:2103425"
     description: "GPL NETBIOS SMB CoGetInstanceFromFile attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3358,8 +3262,7 @@ rules:
         flag: "dce.isystemactivator.bind"
   - name: "sid:2103426"
     description: "GPL NETBIOS SMB CoGetInstanceFromFile little endian attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3404,8 +3307,7 @@ rules:
         flag: "dce.isystemactivator.bind"
   - name: "sid:2103177"
     description: "GPL NETBIOS SMB CoGetInstanceFromFile little endian overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3450,8 +3352,7 @@ rules:
         flag: "smb.tree.bind.msqueue"
   - name: "sid:2103176"
     description: "GPL NETBIOS SMB CoGetInstanceFromFile overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3496,8 +3397,7 @@ rules:
         flag: "smb.tree.bind.msqueue"
   - name: "sid:2103427"
     description: "GPL NETBIOS SMB CoGetInstanceFromFile unicode attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3542,8 +3442,7 @@ rules:
         flag: "dce.isystemactivator.bind"
   - name: "sid:2103428"
     description: "GPL NETBIOS SMB CoGetInstanceFromFile unicode little endian attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3588,8 +3487,7 @@ rules:
         flag: "dce.isystemactivator.bind"
   - name: "sid:2103179"
     description: "GPL NETBIOS SMB CoGetInstanceFromFile unicode little endian overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3634,8 +3532,7 @@ rules:
         flag: "smb.tree.bind.msqueue"
   - name: "sid:2103178"
     description: "GPL NETBIOS SMB CoGetInstanceFromFile unicode overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3680,8 +3577,7 @@ rules:
         flag: "smb.tree.bind.msqueue"
   - name: "sid:2102942"
     description: "GPL NETBIOS SMB InitiateSystemShutdown attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3717,8 +3613,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2102943"
     description: "GPL NETBIOS SMB InitiateSystemShutdown little endian attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3754,8 +3649,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2102944"
     description: "GPL NETBIOS SMB InitiateSystemShutdown unicode attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3791,8 +3685,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2102945"
     description: "GPL NETBIOS SMB InitiateSystemShutdown unicode little endian attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3828,8 +3721,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2103256"
     description: "GPL NETBIOS SMB IrotIsRunning attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3874,8 +3766,7 @@ rules:
         flag: "smb.tree.bind.irot"
   - name: "sid:2103257"
     description: "GPL NETBIOS SMB IrotIsRunning little endian attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3920,8 +3811,7 @@ rules:
         flag: "smb.tree.bind.irot"
   - name: "sid:2103258"
     description: "GPL NETBIOS SMB IrotIsRunning unicode attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -3966,8 +3856,7 @@ rules:
         flag: "smb.tree.bind.irot"
   - name: "sid:2103259"
     description: "GPL NETBIOS SMB IrotIsRunning unicode little endian attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -4012,8 +3901,7 @@ rules:
         flag: "smb.tree.bind.irot"
   - name: "sid:2102946"
     description: "GPL NETBIOS SMB NDdeSetTrustedShareW little endian overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -4049,8 +3937,7 @@ rules:
         flag: "smb.tree.bind.nddeapi"
   - name: "sid:2102936"
     description: "GPL NETBIOS SMB NDdeSetTrustedShareW overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -4086,8 +3973,7 @@ rules:
         flag: "smb.tree.bind.nddeapi"
   - name: "sid:2102947"
     description: "GPL NETBIOS SMB NDdeSetTrustedShareW unicode little endian overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -4123,8 +4009,7 @@ rules:
         flag: "smb.tree.bind.nddeapi"
   - name: "sid:2102937"
     description: "GPL NETBIOS SMB NDdeSetTrustedShareW unicode overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -4160,8 +4045,7 @@ rules:
         flag: "smb.tree.bind.nddeapi"
   - name: "sid:2103018"
     description: "GPL NETBIOS SMB NT Trans NT CREATE oversized Security Descriptor attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -4194,8 +4078,7 @@ rules:
       to_server: true
   - name: "sid:2103020"
     description: "GPL NETBIOS SMB NT Trans NT CREATE unicode oversized Security Descriptor attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -4228,8 +4111,7 @@ rules:
       to_server: true
   - name: "sid:2103219"
     description: "GPL NETBIOS SMB OpenKey little endian overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -4274,8 +4156,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2103218"
     description: "GPL NETBIOS SMB OpenKey overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -4320,8 +4201,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2103221"
     description: "GPL NETBIOS SMB OpenKey unicode little endian overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -4366,8 +4246,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2103220"
     description: "GPL NETBIOS SMB OpenKey unicode overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -4412,8 +4291,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2103409"
     description: "GPL NETBIOS SMB RemoteActivation attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -4458,8 +4336,7 @@ rules:
         flag: "dce.iactivation.bind"
   - name: "sid:2103410"
     description: "GPL NETBIOS SMB RemoteActivation little endian attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -4504,8 +4381,7 @@ rules:
         flag: "dce.iactivation.bind"
   - name: "sid:2103411"
     description: "GPL NETBIOS SMB RemoteActivation unicode attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -4550,8 +4426,7 @@ rules:
         flag: "dce.iactivation.bind"
   - name: "sid:2103412"
     description: "GPL NETBIOS SMB RemoteActivation unicode little endian attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -4596,8 +4471,7 @@ rules:
         flag: "dce.iactivation.bind"
   - name: "sid:2103115"
     description: "GPL NETBIOS SMB llsrconnect little endian overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -4642,8 +4516,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103114"
     description: "GPL NETBIOS SMB llsrconnect overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -4688,8 +4561,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103117"
     description: "GPL NETBIOS SMB llsrconnect unicode little endian overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -4734,8 +4606,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103116"
     description: "GPL NETBIOS SMB llsrconnect unicode overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -4780,8 +4651,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103090"
     description: "GPL NETBIOS SMB llsrpc create tree attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -4808,8 +4678,7 @@ rules:
         flag: "smb.tree.connect.ipc"
   - name: "sid:2103433"
     description: "GPL NETBIOS SMB-DS CoGetInstanceFromFile attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -4854,8 +4723,7 @@ rules:
         flag: "dce.isystemactivator.bind"
   - name: "sid:2103434"
     description: "GPL NETBIOS SMB-DS CoGetInstanceFromFile little endian attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -4900,8 +4768,7 @@ rules:
         flag: "dce.isystemactivator.bind"
   - name: "sid:2103185"
     description: "GPL NETBIOS SMB-DS CoGetInstanceFromFile little endian overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -4946,8 +4813,7 @@ rules:
         flag: "smb.tree.bind.msqueue"
   - name: "sid:2103184"
     description: "GPL NETBIOS SMB-DS CoGetInstanceFromFile overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -4992,8 +4858,7 @@ rules:
         flag: "smb.tree.bind.msqueue"
   - name: "sid:2103435"
     description: "GPL NETBIOS SMB-DS CoGetInstanceFromFile unicode attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -5038,8 +4903,7 @@ rules:
         flag: "dce.isystemactivator.bind"
   - name: "sid:2103436"
     description: "GPL NETBIOS SMB-DS CoGetInstanceFromFile unicode little endian attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -5084,8 +4948,7 @@ rules:
         flag: "dce.isystemactivator.bind"
   - name: "sid:2103187"
     description: "GPL NETBIOS SMB-DS CoGetInstanceFromFile unicode little endian overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -5130,8 +4993,7 @@ rules:
         flag: "smb.tree.bind.msqueue"
   - name: "sid:2103186"
     description: "GPL NETBIOS SMB-DS CoGetInstanceFromFile unicode overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -5176,8 +5038,7 @@ rules:
         flag: "smb.tree.bind.msqueue"
   - name: "sid:2102468"
     description: "GPL NETBIOS SMB-DS D$ share access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -5201,8 +5062,7 @@ rules:
       to_server: true
   - name: "sid:2102469"
     description: "GPL NETBIOS SMB-DS D$ unicode share access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -5226,8 +5086,7 @@ rules:
       to_server: true
   - name: "sid:2103264"
     description: "GPL NETBIOS SMB-DS IrotIsRunning attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -5272,8 +5131,7 @@ rules:
         flag: "smb.tree.bind.irot"
   - name: "sid:2103265"
     description: "GPL NETBIOS SMB-DS IrotIsRunning little endian attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -5318,8 +5176,7 @@ rules:
         flag: "smb.tree.bind.irot"
   - name: "sid:2103266"
     description: "GPL NETBIOS SMB-DS IrotIsRunning unicode attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -5364,8 +5221,7 @@ rules:
         flag: "smb.tree.bind.irot"
   - name: "sid:2103267"
     description: "GPL NETBIOS SMB-DS IrotIsRunning unicode little endian attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -5410,8 +5266,7 @@ rules:
         flag: "smb.tree.bind.irot"
   - name: "sid:2102948"
     description: "GPL NETBIOS SMB-DS NDdeSetTrustedShareW little endian overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -5447,8 +5302,7 @@ rules:
         flag: "smb.tree.bind.nddeapi"
   - name: "sid:2102939"
     description: "GPL NETBIOS SMB-DS NDdeSetTrustedShareW unicode overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -5484,8 +5338,7 @@ rules:
         flag: "smb.tree.bind.nddeapi"
   - name: "sid:2103024"
     description: "GPL NETBIOS SMB-DS NT Trans NT CREATE unicode oversized Security Descriptor attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -5518,8 +5371,7 @@ rules:
       to_server: true
   - name: "sid:2103227"
     description: "GPL NETBIOS SMB-DS OpenKey little endian overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -5564,8 +5416,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2103226"
     description: "GPL NETBIOS SMB-DS OpenKey overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -5610,8 +5461,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2103229"
     description: "GPL NETBIOS SMB-DS OpenKey unicode little endian overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -5656,8 +5506,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2103228"
     description: "GPL NETBIOS SMB-DS OpenKey unicode overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -5702,8 +5551,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2103417"
     description: "GPL NETBIOS SMB-DS RemoteActivation attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -5748,8 +5596,7 @@ rules:
         flag: "dce.iactivation.bind"
   - name: "sid:2103418"
     description: "GPL NETBIOS SMB-DS RemoteActivation little endian attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -5794,8 +5641,7 @@ rules:
         flag: "dce.iactivation.bind"
   - name: "sid:2103419"
     description: "GPL NETBIOS SMB-DS RemoteActivation unicode attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -5840,8 +5686,7 @@ rules:
         flag: "dce.iactivation.bind"
   - name: "sid:2103420"
     description: "GPL NETBIOS SMB-DS RemoteActivation unicode little endian attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -5886,8 +5731,7 @@ rules:
         flag: "dce.iactivation.bind"
   - name: "sid:2103123"
     description: "GPL NETBIOS SMB-DS llsrconnect little endian overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -5932,8 +5776,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103122"
     description: "GPL NETBIOS SMB-DS llsrconnect overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -5978,8 +5821,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103125"
     description: "GPL NETBIOS SMB-DS llsrconnect unicode little endian overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -6024,8 +5866,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103124"
     description: "GPL NETBIOS SMB-DS llsrconnect unicode overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -6070,8 +5911,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2102938"
     description: "GPL NETBIOS SMB-DS NDdeSetTrustedShareW overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -6107,8 +5947,7 @@ rules:
         flag: "smb.tree.bind.nddeapi"
   - name: "sid:2102949"
     description: "GPL NETBIOS SMB-DS NDdeSetTrustedShareW unicode little endian overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -6144,8 +5983,7 @@ rules:
         flag: "smb.tree.bind.nddeapi"
   - name: "sid:2100536"
     description: "GPL NETBIOS SMB D$ share access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -6169,8 +6007,7 @@ rules:
       to_server: true
   - name: "sid:2100533"
     description: "GPL NETBIOS SMB C$ share access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -6194,8 +6031,7 @@ rules:
       to_server: true
   - name: "sid:2100532"
     description: "GPL NETBIOS SMB ADMIN$ share access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -6219,8 +6055,7 @@ rules:
       to_server: true
   - name: "sid:2102383"
     description: "GPL NETBIOS SMB-DS Session Setup NTMLSSP asn1 overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -6253,8 +6088,7 @@ rules:
       to_server: true
   - name: "sid:2103003"
     description: "GPL NETBIOS SMB-DS Session Setup NTMLSSP unicode asn1 overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -6319,8 +6153,7 @@ rules:
       established: true
   - name: "sid:2103437"
     description: "GPL NETBIOS SMB-DS CoGetInstanceFromFile andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -6365,8 +6198,7 @@ rules:
         flag: "dce.isystemactivator.bind"
   - name: "sid:2103429"
     description: "GPL NETBIOS SMB CoGetInstanceFromFile andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -6519,8 +6351,7 @@ rules:
         flag: "smb.tree.bind.irot"
   - name: "sid:2103180"
     description: "GPL NETBIOS SMB CoGetInstanceFromFile andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -6565,8 +6396,7 @@ rules:
         flag: "smb.tree.bind.msqueue"
   - name: "sid:2103430"
     description: "GPL NETBIOS SMB CoGetInstanceFromFile little endian andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -6611,8 +6441,7 @@ rules:
         flag: "dce.isystemactivator.bind"
   - name: "sid:2103181"
     description: "GPL NETBIOS SMB CoGetInstanceFromFile little endian andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -6657,8 +6486,7 @@ rules:
         flag: "smb.tree.bind.msqueue"
   - name: "sid:2103431"
     description: "GPL NETBIOS SMB CoGetInstanceFromFile unicode andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -6703,8 +6531,7 @@ rules:
         flag: "dce.isystemactivator.bind"
   - name: "sid:2103182"
     description: "GPL NETBIOS SMB CoGetInstanceFromFile unicode andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -6749,8 +6576,7 @@ rules:
         flag: "smb.tree.bind.msqueue"
   - name: "sid:2103432"
     description: "GPL NETBIOS SMB CoGetInstanceFromFile unicode little endian andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -6795,8 +6621,7 @@ rules:
         flag: "dce.isystemactivator.bind"
   - name: "sid:2103260"
     description: "GPL NETBIOS SMB IrotIsRunning andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -6841,8 +6666,7 @@ rules:
         flag: "smb.tree.bind.irot"
   - name: "sid:2103261"
     description: "GPL NETBIOS SMB IrotIsRunning little endian andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -6887,8 +6711,7 @@ rules:
         flag: "smb.tree.bind.irot"
   - name: "sid:2103262"
     description: "GPL NETBIOS SMB IrotIsRunning unicode andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -6933,8 +6756,7 @@ rules:
         flag: "smb.tree.bind.irot"
   - name: "sid:2103263"
     description: "GPL NETBIOS SMB IrotIsRunning unicode little endian andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -6979,8 +6801,7 @@ rules:
         flag: "smb.tree.bind.irot"
   - name: "sid:2103022"
     description: "GPL NETBIOS SMB-DS NT Trans NT CREATE oversized Security Descriptor attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7013,8 +6834,7 @@ rules:
       to_server: true
   - name: "sid:2103019"
     description: "GPL NETBIOS SMB NT Trans NT CREATE andx oversized Security Descriptor attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7047,8 +6867,7 @@ rules:
       to_server: true
   - name: "sid:2103034"
     description: "GPL NETBIOS SMB NT Trans NT CREATE DACL overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7081,8 +6900,7 @@ rules:
       to_server: true
   - name: "sid:2103026"
     description: "GPL NETBIOS SMB NT Trans NT CREATE SACL overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7115,8 +6933,7 @@ rules:
       to_server: true
   - name: "sid:2103035"
     description: "GPL NETBIOS SMB NT Trans NT CREATE andx DACL overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7149,8 +6966,7 @@ rules:
       to_server: true
   - name: "sid:2103027"
     description: "GPL NETBIOS SMB NT Trans NT CREATE andx SACL overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7183,8 +6999,7 @@ rules:
       to_server: true
   - name: "sid:2103042"
     description: "GPL NETBIOS SMB NT Trans NT CREATE invalid SACL ace size dos attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7207,8 +7022,7 @@ rules:
       stateless: true
   - name: "sid:2103050"
     description: "GPL NETBIOS SMB NT Trans NT CREATE invalid SACL ace size dos attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7231,8 +7045,7 @@ rules:
       stateless: true
   - name: "sid:2103036"
     description: "GPL NETBIOS SMB NT Trans NT CREATE unicode DACL overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7265,8 +7078,7 @@ rules:
       to_server: true
   - name: "sid:2103028"
     description: "GPL NETBIOS SMB NT Trans NT CREATE unicode SACL overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7299,8 +7111,7 @@ rules:
       to_server: true
   - name: "sid:2103029"
     description: "GPL NETBIOS SMB NT Trans NT CREATE unicode andx SACL overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7333,8 +7144,7 @@ rules:
       to_server: true
   - name: "sid:2103044"
     description: "GPL NETBIOS SMB NT Trans NT CREATE unicode invalid SACL ace size dos attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7357,8 +7167,7 @@ rules:
       stateless: true
   - name: "sid:2103052"
     description: "GPL NETBIOS SMB NT Trans NT CREATE unicode invalid SACL ace size dos attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7381,8 +7190,7 @@ rules:
       stateless: true
   - name: "sid:2103038"
     description: "GPL NETBIOS SMB-DS NT Trans NT CREATE DACL overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7415,8 +7223,7 @@ rules:
       to_server: true
   - name: "sid:2103030"
     description: "GPL NETBIOS SMB-DS NT Trans NT CREATE SACL overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7449,8 +7256,7 @@ rules:
       to_server: true
   - name: "sid:2103046"
     description: "GPL NETBIOS SMB-DS NT Trans NT CREATE invalid SACL ace size dos attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7473,8 +7279,7 @@ rules:
       stateless: true
   - name: "sid:2103054"
     description: "GPL NETBIOS SMB-DS NT Trans NT CREATE invalid SACL ace size dos attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7497,8 +7302,7 @@ rules:
       stateless: true
   - name: "sid:2103040"
     description: "GPL NETBIOS SMB-DS NT Trans NT CREATE unicode DACL overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7531,8 +7335,7 @@ rules:
       to_server: true
   - name: "sid:2103032"
     description: "GPL NETBIOS SMB-DS NT Trans NT CREATE unicode SACL overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7565,8 +7368,7 @@ rules:
       to_server: true
   - name: "sid:2103048"
     description: "GPL NETBIOS SMB-DS NT Trans NT CREATE unicode invalid SACL ace size dos attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7589,8 +7391,7 @@ rules:
       stateless: true
   - name: "sid:2103056"
     description: "GPL NETBIOS SMB-DS NT Trans NT CREATE unicode invalid SACL ace size dos attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7613,8 +7414,7 @@ rules:
       stateless: true
   - name: "sid:2103222"
     description: "GPL NETBIOS SMB OpenKey andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7659,8 +7459,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2103223"
     description: "GPL NETBIOS SMB OpenKey little endian andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7705,8 +7504,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2103224"
     description: "GPL NETBIOS SMB OpenKey unicode andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7751,8 +7549,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2103225"
     description: "GPL NETBIOS SMB OpenKey unicode little endian andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7797,8 +7594,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2103413"
     description: "GPL NETBIOS SMB RemoteActivation andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7843,8 +7639,7 @@ rules:
         flag: "dce.iactivation.bind"
   - name: "sid:2103414"
     description: "GPL NETBIOS SMB RemoteActivation little endian andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7889,8 +7684,7 @@ rules:
         flag: "dce.iactivation.bind"
   - name: "sid:2103415"
     description: "GPL NETBIOS SMB RemoteActivation unicode andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7935,8 +7729,7 @@ rules:
         flag: "dce.iactivation.bind"
   - name: "sid:2103416"
     description: "GPL NETBIOS SMB RemoteActivation unicode little endian andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -7981,8 +7774,7 @@ rules:
         flag: "dce.iactivation.bind"
   - name: "sid:2103001"
     description: "GPL NETBIOS SMB Session Setup NTMLSSP andx asn1 overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -8015,8 +7807,7 @@ rules:
       to_server: true
   - name: "sid:2103002"
     description: "GPL NETBIOS SMB Session Setup NTMLSSP unicode andx asn1 overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -8049,8 +7840,7 @@ rules:
       to_server: true
   - name: "sid:2103118"
     description: "GPL NETBIOS SMB llsrconnect andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -8095,8 +7885,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103119"
     description: "GPL NETBIOS SMB llsrconnect little endian andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -8141,8 +7930,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103120"
     description: "GPL NETBIOS SMB llsrconnect unicode andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -8187,8 +7975,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103121"
     description: "GPL NETBIOS SMB llsrconnect unicode little endian andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -8233,8 +8020,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103188"
     description: "GPL NETBIOS SMB-DS CoGetInstanceFromFile andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -8279,8 +8065,7 @@ rules:
         flag: "smb.tree.bind.msqueue"
   - name: "sid:2103438"
     description: "GPL NETBIOS SMB-DS CoGetInstanceFromFile little endian andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -8325,8 +8110,7 @@ rules:
         flag: "dce.isystemactivator.bind"
   - name: "sid:2103189"
     description: "GPL NETBIOS SMB-DS CoGetInstanceFromFile little endian andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -8371,8 +8155,7 @@ rules:
         flag: "smb.tree.bind.msqueue"
   - name: "sid:2103439"
     description: "GPL NETBIOS SMB-DS CoGetInstanceFromFile unicode andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -8417,8 +8200,7 @@ rules:
         flag: "dce.isystemactivator.bind"
   - name: "sid:2103190"
     description: "GPL NETBIOS SMB-DS CoGetInstanceFromFile unicode andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -8463,8 +8245,7 @@ rules:
         flag: "smb.tree.bind.msqueue"
   - name: "sid:2103440"
     description: "GPL NETBIOS SMB-DS CoGetInstanceFromFile unicode little endian andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -8509,8 +8290,7 @@ rules:
         flag: "dce.isystemactivator.bind"
   - name: "sid:2103191"
     description: "GPL NETBIOS SMB-DS CoGetInstanceFromFile unicode little endian andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -8555,8 +8335,7 @@ rules:
         flag: "smb.tree.bind.msqueue"
   - name: "sid:2103268"
     description: "GPL NETBIOS SMB-DS IrotIsRunning andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -8601,8 +8380,7 @@ rules:
         flag: "smb.tree.bind.irot"
   - name: "sid:2103269"
     description: "GPL NETBIOS SMB-DS IrotIsRunning little endian andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -8647,8 +8425,7 @@ rules:
         flag: "smb.tree.bind.irot"
   - name: "sid:2103270"
     description: "GPL NETBIOS SMB-DS IrotIsRunning unicode andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -8693,8 +8470,7 @@ rules:
         flag: "smb.tree.bind.irot"
   - name: "sid:2103271"
     description: "GPL NETBIOS SMB-DS IrotIsRunning unicode little endian andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -8739,8 +8515,7 @@ rules:
         flag: "smb.tree.bind.irot"
   - name: "sid:2103230"
     description: "GPL NETBIOS SMB-DS OpenKey andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -8785,8 +8560,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2103231"
     description: "GPL NETBIOS SMB-DS OpenKey little endian andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -8831,8 +8605,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2103232"
     description: "GPL NETBIOS SMB-DS OpenKey unicode andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -8877,8 +8650,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2103233"
     description: "GPL NETBIOS SMB-DS OpenKey unicode little endian andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -8923,8 +8695,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2103421"
     description: "GPL NETBIOS SMB-DS RemoteActivation andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -8969,8 +8740,7 @@ rules:
         flag: "dce.iactivation.bind"
   - name: "sid:2103422"
     description: "GPL NETBIOS SMB-DS RemoteActivation little endian andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -9015,8 +8785,7 @@ rules:
         flag: "dce.iactivation.bind"
   - name: "sid:2103423"
     description: "GPL NETBIOS SMB-DS RemoteActivation unicode andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -9061,8 +8830,7 @@ rules:
         flag: "dce.iactivation.bind"
   - name: "sid:2103424"
     description: "GPL NETBIOS SMB-DS RemoteActivation unicode little endian andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -9107,8 +8875,7 @@ rules:
         flag: "dce.iactivation.bind"
   - name: "sid:2103126"
     description: "GPL NETBIOS SMB-DS llsrconnect andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -9153,8 +8920,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103127"
     description: "GPL NETBIOS SMB-DS llsrconnect little endian andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -9199,8 +8965,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103128"
     description: "GPL NETBIOS SMB-DS llsrconnect unicode andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -9245,8 +9010,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103129"
     description: "GPL NETBIOS SMB-DS llsrconnect unicode little endian andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -9291,8 +9055,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103097"
     description: "GPL NETBIOS SMB-DS llsrpc unicode andx create tree attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -9344,8 +9107,7 @@ rules:
       to_server: true
   - name: "sid:2102316"
     description: "GPL NETBIOS DCERPC Workstation Service direct service access attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -9366,16 +9128,14 @@ rules:
         no_case: false
   - name: "sid:2102313"
     description: "GPL SHELLCODE x86 0x71FB7BAB NOOP unicode"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:q\u0000�\u0000\\{\u0000�\u0000q\u0000�\u0000\\{\u0000�\u0000q\u0000�\u0000\\{\u0000�\u0000q\u0000�\u0000\\{\u0000�\u0000)"
       case_insensitive: false
   - name: "sid:2102312"
     description: "GPL SHELLCODE x86 0x71FB7BAB NOOP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:q�\\{�q�\\{�q�\\{�q�\\{�)"
@@ -9412,8 +9172,7 @@ rules:
         no_case: false
   - name: "sid:2102256"
     description: "GPL RPC sadmind query with root credentials attempt UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -9421,8 +9180,7 @@ rules:
       case_insensitive: false
   - name: "sid:2102185"
     description: "GPL RPC mountd UDP mount path overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -9440,8 +9198,7 @@ rules:
         no_case: false
   - name: "sid:2102035"
     description: "GPL RPC portmap network-status-monitor request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -9474,8 +9231,7 @@ rules:
       to_client: true
   - name: "sid:2012882"
     description: "ET MALWARE Backdoor.Win32.Poison.AU checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -9566,8 +9322,7 @@ rules:
       to_server: true
   - name: "sid:2013911"
     description: "ET MALWARE P2P Zeus or ZeroAccess Request To CnC"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -9604,8 +9359,7 @@ rules:
       to_server: true
   - name: "sid:2015474"
     description: "ET MALWARE ZeroAccess udp traffic detected"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -9680,8 +9434,7 @@ rules:
       to_server: true
   - name: "sid:2100585"
     description: "GPL RPC portmap sadmind request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -9692,8 +9445,7 @@ rules:
       case_insensitive: false
   - name: "sid:2100589"
     description: "GPL RPC portmap yppasswd request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -9704,8 +9456,7 @@ rules:
       case_insensitive: false
   - name: "sid:2100590"
     description: "GPL RPC portmap ypserv request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -9723,64 +9474,56 @@ rules:
       case_insensitive: false
   - name: "sid:2100641"
     description: "GPL SHELLCODE Digital UNIX NOOP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:G�\u0004\u001fG�\u0004\u001fG�\u0004\u001fG�\u0004\u001f)"
       case_insensitive: false
   - name: "sid:2100642"
     description: "GPL SHELLCODE HP-UX NOOP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0008!\u0002�\u0008!\u0002�\u0008!\u0002�\u0008!\u0002�)"
       case_insensitive: false
   - name: "sid:2100643"
     description: "GPL SHELLCODE HP-UX NOOP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\\\u000b9\u0002�\\\u000b9\u0002�\\\u000b9\u0002�\\\u000b9\u0002�)"
       case_insensitive: false
   - name: "sid:2100644"
     description: "GPL SHELLCODE sparc NOOP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0013�\u001c�\u0013�\u001c�\u0013�\u001c�\u0013�\u001c�)"
       case_insensitive: false
   - name: "sid:2100645"
     description: "GPL SHELLCODE sparc NOOP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�\u001c@\u0011�\u001c@\u0011�\u001c@\u0011�\u001c@\u0011)"
       case_insensitive: false
   - name: "sid:2100646"
     description: "GPL SHELLCODE sparc NOOP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�\u001c�\u0013�\u001c�\u0013�\u001c�\u0013�\u001c�\u0013)"
       case_insensitive: false
   - name: "sid:2100647"
     description: "GPL SHELLCODE sparc setuid 0"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�\u0010\\ \u0017��\\ \u0008)"
       case_insensitive: false
   - name: "sid:2100652"
     description: "GPL SHELLCODE Linux shellcode"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:��������/bin/sh)"
@@ -9822,8 +9565,7 @@ rules:
       case_insensitive: false
   - name: "sid:2103183"
     description: "GPL NETBIOS SMB CoGetInstanceFromFile unicode little endian andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -10024,8 +9766,7 @@ rules:
       to_server: true
   - name: "sid:2102999"
     description: "GPL NETBIOS SMB-DS InitiateSystemShutdown unicode little endian andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -10061,8 +9802,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2102998"
     description: "GPL NETBIOS SMB-DS InitiateSystemShutdown unicode andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -10098,8 +9838,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2102997"
     description: "GPL NETBIOS SMB-DS InitiateSystemShutdown little endian andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -10135,8 +9874,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2102996"
     description: "GPL NETBIOS SMB-DS InitiateSystemShutdown andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -10172,8 +9910,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2102995"
     description: "GPL NETBIOS SMB InitiateSystemShutdown unicode little endian andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -10209,8 +9946,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2102994"
     description: "GPL NETBIOS SMB InitiateSystemShutdown unicode andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -10246,8 +9982,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2102993"
     description: "GPL NETBIOS SMB InitiateSystemShutdown little endian andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -10283,8 +10018,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2102992"
     description: "GPL NETBIOS SMB InitiateSystemShutdown andx attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -10320,8 +10054,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2102964"
     description: "GPL NETBIOS SMB NDdeSetTrustedShareW andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -10357,8 +10090,7 @@ rules:
         flag: "smb.tree.bind.nddeapi"
   - name: "sid:2102965"
     description: "GPL NETBIOS SMB NDdeSetTrustedShareW little endian andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -10394,8 +10126,7 @@ rules:
         flag: "smb.tree.bind.nddeapi"
   - name: "sid:2102966"
     description: "GPL NETBIOS SMB NDdeSetTrustedShareW unicode andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -10431,8 +10162,7 @@ rules:
         flag: "smb.tree.bind.nddeapi"
   - name: "sid:2102967"
     description: "GPL NETBIOS SMB NDdeSetTrustedShareW unicode little endian andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -10468,8 +10198,7 @@ rules:
         flag: "smb.tree.bind.nddeapi"
   - name: "sid:2102982"
     description: "GPL NETBIOS SMB-DS ADMIN$ andx share access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -10493,8 +10222,7 @@ rules:
       to_server: true
   - name: "sid:2102983"
     description: "GPL NETBIOS SMB-DS ADMIN$ unicode andx share access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -10518,8 +10246,7 @@ rules:
       to_server: true
   - name: "sid:2102979"
     description: "GPL NETBIOS SMB-DS C$ unicode andx share access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -10543,8 +10270,7 @@ rules:
       to_server: true
   - name: "sid:2102975"
     description: "GPL NETBIOS SMB-DS D$ unicode andx share access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -10568,8 +10294,7 @@ rules:
       to_server: true
   - name: "sid:2102968"
     description: "GPL NETBIOS SMB-DS NDdeSetTrustedShareW andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -10605,8 +10330,7 @@ rules:
         flag: "smb.tree.bind.nddeapi"
   - name: "sid:2102969"
     description: "GPL NETBIOS SMB-DS NDdeSetTrustedShareW little endian andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -10642,8 +10366,7 @@ rules:
         flag: "smb.tree.bind.nddeapi"
   - name: "sid:2102970"
     description: "GPL NETBIOS SMB-DS NDdeSetTrustedShareW unicode andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -10679,8 +10402,7 @@ rules:
         flag: "smb.tree.bind.nddeapi"
   - name: "sid:2102971"
     description: "GPL NETBIOS SMB-DS NDdeSetTrustedShareW unicode little endian andx overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -10716,8 +10438,7 @@ rules:
         flag: "smb.tree.bind.nddeapi"
   - name: "sid:2100575"
     description: "GPL RPC portmap admind request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -10728,8 +10449,7 @@ rules:
       case_insensitive: false
   - name: "sid:2100576"
     description: "GPL RPC portmap amountd request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -10740,8 +10460,7 @@ rules:
       case_insensitive: false
   - name: "sid:2100577"
     description: "GPL RPC portmap bootparam request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -10752,8 +10471,7 @@ rules:
       case_insensitive: false
   - name: "sid:2100578"
     description: "GPL RPC portmap cmsd request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -10764,8 +10482,7 @@ rules:
       case_insensitive: false
   - name: "sid:2101280"
     description: "GPL RPC portmap listing UDP 111"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -10776,8 +10493,7 @@ rules:
       case_insensitive: false
   - name: "sid:2100579"
     description: "GPL RPC portmap mountd request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -10788,8 +10504,7 @@ rules:
       case_insensitive: false
   - name: "sid:2100580"
     description: "GPL RPC portmap nisd request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -10800,8 +10515,7 @@ rules:
       case_insensitive: false
   - name: "sid:2100581"
     description: "GPL RPC portmap pcnfsd request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -10812,8 +10526,7 @@ rules:
       case_insensitive: false
   - name: "sid:2100582"
     description: "GPL RPC portmap rexd request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -10824,8 +10537,7 @@ rules:
       case_insensitive: false
   - name: "sid:2100583"
     description: "GPL RPC portmap rstatd request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -10836,8 +10548,7 @@ rules:
       case_insensitive: false
   - name: "sid:2100584"
     description: "GPL RPC portmap rusers request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -10848,8 +10559,7 @@ rules:
       case_insensitive: false
   - name: "sid:2100586"
     description: "GPL RPC portmap selection_svc request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -10860,8 +10570,7 @@ rules:
       case_insensitive: false
   - name: "sid:2101279"
     description: "GPL RPC portmap snmpXdmi request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -10872,8 +10581,7 @@ rules:
       case_insensitive: false
   - name: "sid:2100587"
     description: "GPL RPC portmap status request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -10884,8 +10592,7 @@ rules:
       case_insensitive: false
   - name: "sid:2100588"
     description: "GPL RPC portmap ttdbserv request UDP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -10939,8 +10646,7 @@ rules:
       established: true
   - name: "sid:2015842"
     description: "ET INFO LLNMR query response to wpad"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -10951,8 +10657,7 @@ rules:
       case_insensitive: false
   - name: "sid:2016145"
     description: "ET INFO PTUNNEL OUTBOUND"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: icmp
     action: traffic_attack
     regex:
@@ -10960,8 +10665,7 @@ rules:
       case_insensitive: false
   - name: "sid:2016146"
     description: "ET INFO PTUNNEL INBOUND"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: icmp
     action: traffic_attack
     regex:
@@ -11208,8 +10912,7 @@ rules:
       to_server: true
   - name: "sid:2009967"
     description: "ET P2P eMule KAD Network Connection Request"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -11236,8 +10939,7 @@ rules:
       to_server: true
   - name: "sid:2015482"
     description: "ET MALWARE ZeroAccess Outbound udp traffic detected"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -11926,8 +11628,7 @@ rules:
       exact: 32
   - name: "sid:2018467"
     description: "ET MALWARE PandoraRat/Refroso.bsp Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -11960,8 +11661,7 @@ rules:
       to_server: true
   - name: "sid:2018555"
     description: "ET MALWARE Putter Panda 3PARA RAT initial beacon"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -12360,8 +12060,7 @@ rules:
       case_insensitive: false
   - name: "sid:2019171"
     description: "ET MALWARE DoS.Linux/Elknot.E Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -12418,8 +12117,7 @@ rules:
       to_server: true
   - name: "sid:2010144"
     description: "ET P2P Vuze BT UDP Connection (5)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -12445,8 +12143,7 @@ rules:
       to_server: true
   - name: "sid:2016474"
     description: "ET MALWARE CommentCrew UGX Backdoor initial connection"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -12499,8 +12196,7 @@ rules:
         flag: "ET.Onelouder.bin"
   - name: "sid:2019207"
     description: "ET MALWARE Linux/BillGates Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -12580,8 +12276,7 @@ rules:
       to_server: true
   - name: "sid:2016016"
     description: "ET DOS DNS Amplification Attack Inbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -12685,8 +12380,7 @@ rules:
       to_client: true
   - name: "sid:2019491"
     description: "ET EXPLOIT Possible Malicious NAT-PMP Response Successful TCP Map to External Network"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -12699,8 +12393,7 @@ rules:
       exact: 16
   - name: "sid:2019492"
     description: "ET EXPLOIT Possible Malicious NAT-PMP Response Successful UDP Map to External Network"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -13090,8 +12783,7 @@ rules:
       to_server: true
   - name: "sid:2019740"
     description: "ET MALWARE OSX/AlienSpy RAT Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -13149,8 +12841,7 @@ rules:
       to_client: true
   - name: "sid:2019808"
     description: "ET MALWARE W32/DoubleTap.APT Downloader CnC Beacon"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -13586,8 +13277,7 @@ rules:
         no_case: false
   - name: "sid:2019022"
     description: "ET DOS Likely NTP DDoS In Progress Multiple UNSETTRAP Mode 6 Responses"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -13917,8 +13607,7 @@ rules:
       to_server: true
   - name: "sid:2019929"
     description: "ET MALWARE Possible Net Crawler SMB Share Access unicode (Operation Cleaver)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -13942,8 +13631,7 @@ rules:
       to_server: true
   - name: "sid:2019930"
     description: "ET MALWARE Possible Net Crawler SMB Share Access ascii (Operation Cleaver)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -13981,8 +13669,7 @@ rules:
       to_server: true
   - name: "sid:2019994"
     description: "ET MALWARE US-CERT TA14-353A Wiper 2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -13992,8 +13679,7 @@ rules:
       established: true
   - name: "sid:2020018"
     description: "ET MALWARE US-CERT TA14-353A Proxy Tool 2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -14070,8 +13756,7 @@ rules:
       to_client: true
   - name: "sid:2020169"
     description: "ET MALWARE Hong Kong SWC Attack PcClient CnC Beacon"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -14110,8 +13795,7 @@ rules:
       to_server: true
   - name: "sid:2020382"
     description: "ET MALWARE Skeleton Key Filename in SMB2 Traffic"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -14125,8 +13809,7 @@ rules:
       to_server: true
   - name: "sid:2020383"
     description: "ET MALWARE Skeleton Key Filename in SMB2 Traffic"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -14140,8 +13823,7 @@ rules:
       to_server: true
   - name: "sid:2020384"
     description: "ET MALWARE Skeleton Key Filename in SMB2 Traffic"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -14668,8 +14350,7 @@ rules:
       to_server: true
   - name: "sid:2021572"
     description: "ET EXPLOIT Possible BIND9 DoS CVE-2015-5477 M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -14680,8 +14361,7 @@ rules:
       case_insensitive: false
   - name: "sid:2021574"
     description: "ET EXPLOIT Possible BIND9 DoS CVE-2015-5477 M3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -14692,8 +14372,7 @@ rules:
       case_insensitive: false
   - name: "sid:2021575"
     description: "ET EXPLOIT Possible BIND9 DoS CVE-2015-5477 M4"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -14704,8 +14383,7 @@ rules:
       case_insensitive: false
   - name: "sid:2021573"
     description: "ET EXPLOIT Possible BIND9 DoS CVE-2015-5477 M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -14972,8 +14650,7 @@ rules:
       established: true
   - name: "sid:2019214"
     description: "ET MALWARE njrat ver 0.7d Malware CnC Callback (Capture)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -15055,8 +14732,7 @@ rules:
       to_server: true
   - name: "sid:2022345"
     description: "ET MALWARE Win32/Bulta CnC Beacon"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -15067,8 +14743,7 @@ rules:
       to_server: true
   - name: "sid:2014636"
     description: "ET MALWARE FakeM RAT CnC Beacon"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -15137,8 +14812,7 @@ rules:
       to_server: true
   - name: "sid:2022542"
     description: "ET EXPLOIT Possible 2015-7547 PoC Server Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -15481,8 +15155,7 @@ rules:
       to_server: true
   - name: "sid:2022712"
     description: "ET EXPLOIT Dameware DMRC Buffer Overflow Attempt (CVE-2016-2345)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -15496,8 +15169,7 @@ rules:
       to_server: true
   - name: "sid:2022819"
     description: "ET ATTACK_RESPONSE Possible CVE-2016-1287 Inbound Reverse CLI Shellcode"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -15510,8 +15182,7 @@ rules:
       to_server: true
   - name: "sid:2022820"
     description: "ET EXPLOIT CVE-2016-1287 Public Exploit ShellCode"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -15604,8 +15275,7 @@ rules:
       to_server: true
   - name: "sid:2022973"
     description: "ET INFO Possible Kali Linux hostname in DHCP Request Packet"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -15648,8 +15318,7 @@ rules:
       case_insensitive: false
   - name: "sid:2023054"
     description: "ET DOS DNS Amplification Attack Possible Outbound Windows Non-Recursive Root Hint Reserved Port"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -15682,8 +15351,7 @@ rules:
         no_case: false
   - name: "sid:2023053"
     description: "ET DOS DNS Amplification Attack Possible Inbound Windows Non-Recursive Root Hint Reserved Port"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -15716,8 +15384,7 @@ rules:
         no_case: false
   - name: "sid:2023070"
     description: "ET EXPLOIT Equation Group ExtraBacon Cisco ASA PMCHECK Disable"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -15728,8 +15395,7 @@ rules:
       case_insensitive: false
   - name: "sid:2023071"
     description: "ET EXPLOIT Equation Group ExtraBacon Cisco ASA AAAADMINAUTH Disable"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -15740,8 +15406,7 @@ rules:
       case_insensitive: false
   - name: "sid:2023086"
     description: "ET EXPLOIT CISCO FIREWALL SNMP Buffer Overflow Extrabacon (CVE-2016-6366)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -15991,8 +15656,7 @@ rules:
       to_server: true
   - name: "sid:2023311"
     description: "ET EXPLOIT Possible Cisco IKEv1 Information Disclosure Vulnerability CVE-2016-6415"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -16077,8 +15741,7 @@ rules:
       to_server: true
   - name: "sid:2023527"
     description: "ET MALWARE KeyBoy CnC Beacon"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -16152,8 +15815,7 @@ rules:
         no_case: false
   - name: "sid:2019490"
     description: "ET EXPLOIT Possible Malicious NAT-PMP Response to External Network"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -16166,8 +15828,7 @@ rules:
       exact: 12
   - name: "sid:2023716"
     description: "ET MALWARE Linux/Venom CnC Beacon"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -16404,8 +16065,7 @@ rules:
       to_server: true
   - name: "sid:2046914"
     description: "ET MALWARE NanoCore RAT CnC 7"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -16416,8 +16076,7 @@ rules:
       to_server: true
   - name: "sid:2023497"
     description: "ET DOS Microsoft Windows LSASS Remote Memory Corruption (CVE-2017-0004)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -16500,8 +16159,7 @@ rules:
       to_server: true
   - name: "sid:2022506"
     description: "ET EXPLOIT Possible CVE-2016-1287 Invalid Fragment Size Inbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -16533,8 +16191,7 @@ rules:
       to_server: true
   - name: "sid:2022515"
     description: "ET EXPLOIT Possible CVE-2016-1287 Invalid Fragment Size Inbound 2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -16557,8 +16214,7 @@ rules:
       to_server: true
   - name: "sid:2022516"
     description: "ET EXPLOIT Possible CVE-2016-1287 Invalid Fragment Size Inbound 3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -16766,8 +16422,7 @@ rules:
       to_server: true
   - name: "sid:2024297"
     description: "ET EXPLOIT ETERNALBLUE Exploit M2 MS17-010"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -16803,8 +16458,7 @@ rules:
       case_insensitive: false
   - name: "sid:2018558"
     description: "ET MALWARE Win32/Ramnit Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -16820,8 +16474,7 @@ rules:
       to_server: true
   - name: "sid:2024511"
     description: "ET DOS SMBLoris NBSS Length Mem Exhaustion Attempt (PoC Based)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -16835,8 +16488,7 @@ rules:
       to_server: true
   - name: "sid:2024584"
     description: "ET DOS CLDAP Amplification Reflection (PoC based)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -16879,8 +16531,7 @@ rules:
         flag: "ET.NetWire"
   - name: "sid:2014225"
     description: "ET MALWARE LURK Trojan Communication Protocol detected"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -16930,8 +16581,7 @@ rules:
       case_insensitive: false
   - name: "sid:2024898"
     description: "ET MALWARE Possible Dragonfly APT Activity - SMB credential harvesting"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -16945,8 +16595,7 @@ rules:
       to_server: true
   - name: "sid:2003281"
     description: "ET INFO SOCKSv4 Port 5050 Inbound Request (Linux Source)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -16963,8 +16612,7 @@ rules:
       to_server: true
   - name: "sid:2003268"
     description: "ET INFO SOCKSv4 Port 443 Inbound Request (Windows Source)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -16981,8 +16629,7 @@ rules:
       to_server: true
   - name: "sid:2003269"
     description: "ET INFO SOCKSv4 Port 443 Inbound Request (Linux Source)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -17177,8 +16824,7 @@ rules:
       to_server: true
   - name: "sid:2003266"
     description: "ET INFO SOCKSv5 Port 443 Inbound Request (Windows Source)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -17197,8 +16843,7 @@ rules:
       to_server: true
   - name: "sid:2003267"
     description: "ET INFO SOCKSv5 Port 443 Inbound Request (Linux Source)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -17361,8 +17006,7 @@ rules:
       to_server: true
   - name: "sid:2003278"
     description: "ET INFO SOCKSv5 Port 5050 Inbound Request (Windows Source)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -17381,8 +17025,7 @@ rules:
       to_server: true
   - name: "sid:2003279"
     description: "ET INFO SOCKSv5 Port 5050 Inbound Request (Linux Source)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -17401,8 +17044,7 @@ rules:
       to_server: true
   - name: "sid:2003280"
     description: "ET INFO SOCKSv4 Port 5050 Inbound Request (Windows Source)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -17432,8 +17074,7 @@ rules:
       to_server: true
   - name: "sid:2024990"
     description: "ET MALWARE Lazarus FALLCHILL Fake SSL Checkin 1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -17504,8 +17145,7 @@ rules:
       to_server: true
   - name: "sid:2025093"
     description: "ET MALWARE UBoatRAT CnC Check-in"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -17559,8 +17199,7 @@ rules:
       to_server: true
   - name: "sid:2036414"
     description: "ET MALWARE DDoS Win32/Nitol.A Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -17750,8 +17389,7 @@ rules:
       established: true
   - name: "sid:2025520"
     description: "ET EXPLOIT Cisco Smart Install Exploitation Tool - Update Ios and Execute"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -17820,8 +17458,7 @@ rules:
       to_server: true
   - name: "sid:2025581"
     description: "ET MALWARE Win32/Vibem.C CnC Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -17842,8 +17479,7 @@ rules:
       to_client: true
   - name: "sid:2046919"
     description: "ET MALWARE NanoCore RAT CnC 23"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -17856,8 +17492,7 @@ rules:
       to_server: true
   - name: "sid:2025765"
     description: "ET EXPLOIT DynoRoot DHCP - Client Command Injection"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -17871,8 +17506,7 @@ rules:
       case_insensitive: false
   - name: "sid:2025766"
     description: "ET EXPLOIT CloudMe Sync Buffer Overflow"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -18212,8 +17846,7 @@ rules:
       max: 44
   - name: "sid:2025824"
     description: "ET NETBIOS Microsoft Windows RRAS SMB Remote Code Execution"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -18260,8 +17893,7 @@ rules:
       to_server: true
   - name: "sid:2025695"
     description: "ET SHELLCODE Execve(/bin/sh) Shellcode"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:1�Ph//shh/bin��PS��\\\u000b̀)"
@@ -18282,8 +17914,7 @@ rules:
       to_client: true
   - name: "sid:2025700"
     description: "ET INFO SMB NT Create AndX Request For an Executable File"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -18311,8 +17942,7 @@ rules:
       to_server: true
   - name: "sid:2025704"
     description: "ET INFO SMB NT Create AndX Request For a Powershell .ps1 File"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -18340,8 +17970,7 @@ rules:
       to_server: true
   - name: "sid:2025706"
     description: "ET INFO SMB NT Create AndX Request For a .bat File"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -18369,8 +17998,7 @@ rules:
       to_server: true
   - name: "sid:2025708"
     description: "ET INFO SMB NT Create AndX Request For a DLL File"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -18398,8 +18026,7 @@ rules:
       to_server: true
   - name: "sid:2025710"
     description: "ET INFO SMB NT Create AndX Request For a .sys File - Possible Lateral Movement"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -18427,8 +18054,7 @@ rules:
       to_server: true
   - name: "sid:2025712"
     description: "ET INFO SMB Remote AT Scheduled Job Create Request - Possible Lateral Movement"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -18670,8 +18296,7 @@ rules:
       to_server: true
   - name: "sid:2026004"
     description: "ET MALWARE [PTsecurity] Remcos RAT Checkin 26"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -18682,8 +18307,7 @@ rules:
       to_server: true
   - name: "sid:2026005"
     description: "ET SCADA SEIG Modbus 3.4 - Remote Code Execution"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -18697,8 +18321,7 @@ rules:
       to_server: true
   - name: "sid:2025972"
     description: "ET EXPLOIT Mikrotik Winbox RCE Attempt (CVE-2018-14847)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -18768,8 +18391,7 @@ rules:
       to_server: true
   - name: "sid:2026509"
     description: "ET MALWARE [PTsecurity] Remcos RAT Checkin 69"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -18780,8 +18402,7 @@ rules:
       to_server: true
   - name: "sid:2026510"
     description: "ET MALWARE [PTsecurity] Remcos RAT Checkin 70"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -18792,8 +18413,7 @@ rules:
       to_server: true
   - name: "sid:2026511"
     description: "ET MALWARE [PTsecurity] Remcos RAT Checkin 71"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -18804,8 +18424,7 @@ rules:
       to_server: true
   - name: "sid:2026512"
     description: "ET MALWARE [PTsecurity] Remcos RAT Checkin 72"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -18816,8 +18435,7 @@ rules:
       to_server: true
   - name: "sid:2026513"
     description: "ET MALWARE [PTsecurity] Remcos RAT Checkin 73"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -18876,8 +18494,7 @@ rules:
       to_server: true
   - name: "sid:2046915"
     description: "ET MALWARE NanoCore RAT CnC 24"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -18901,8 +18518,7 @@ rules:
       to_server: true
   - name: "sid:2026736"
     description: "ET MALWARE AveMaria Initial CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -18950,8 +18566,7 @@ rules:
       to_server: true
   - name: "sid:2003319"
     description: "ET P2P Edonkey Search Request (search by name)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -18961,8 +18576,7 @@ rules:
       min: 6
   - name: "sid:2026826"
     description: "ET MALWARE [PTsecurity] Bitter RAT C2 Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -18975,8 +18589,7 @@ rules:
       to_client: true
   - name: "sid:2026852"
     description: "ET MALWARE [PTsecurity] Remcos RAT Checkin 85"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -18987,8 +18600,7 @@ rules:
       to_server: true
   - name: "sid:2026853"
     description: "ET MALWARE [PTsecurity] Remcos RAT Checkin 86"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -18999,8 +18611,7 @@ rules:
       to_server: true
   - name: "sid:2026862"
     description: "ET MALWARE [PTsecurity] Remcos RAT Checkin 87"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -19097,8 +18708,7 @@ rules:
       to_server: true
   - name: "sid:2027084"
     description: "ET MALWARE Win32/Termite Agent Implant Keep-Alive"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -19111,8 +18721,7 @@ rules:
       to_server: true
   - name: "sid:2027083"
     description: "ET MALWARE Win32/Termite Agent Implant CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -19507,8 +19116,7 @@ rules:
       to_server: true
   - name: "sid:2027370"
     description: "ET MALWARE Suspected ExtraPulsar Backdoor"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -19838,8 +19446,7 @@ rules:
       to_server: true
   - name: "sid:2027813"
     description: "ET MALWARE Nyanw0rm CnC Keep-Alive (Outbound) M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -19852,8 +19459,7 @@ rules:
       to_server: true
   - name: "sid:2027812"
     description: "ET MALWARE Nyanw0rm CnC Keep-Alive (Outbound) M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -20035,8 +19641,7 @@ rules:
       to_client: true
   - name: "sid:2027892"
     description: "ET MALWARE Win32/Dostre CnC Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -20549,8 +20154,7 @@ rules:
       case_insensitive: false
   - name: "sid:2101427"
     description: "GPL SNMP PROTOS test-suite-trap-app attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -20561,8 +20165,7 @@ rules:
       case_insensitive: false
   - name: "sid:2100516"
     description: "GPL SNMP SNMP NT UserList"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -20593,8 +20196,7 @@ rules:
       established: true
   - name: "sid:2101424"
     description: "GPL SHELLCODE x86 0xEB0C NOOP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�\\\u000c�\\\u000c�\\\u000c�\\\u000c�\\\u000c�\\\u000c�\\\u000c�\\\u000c)"
@@ -20683,8 +20285,7 @@ rules:
       case_insensitive: false
   - name: "sid:2017548"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -20918,8 +20519,7 @@ rules:
       established: true
   - name: "sid:2020008"
     description: "ET MALWARE US-CERT TA14-353A Lightweight Backdoor 2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -20933,8 +20533,7 @@ rules:
       to_server: true
   - name: "sid:2020010"
     description: "ET MALWARE US-CERT TA14-353A Lightweight Backdoor 4"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -20944,8 +20543,7 @@ rules:
       established: true
   - name: "sid:2020012"
     description: "ET MALWARE US-CERT TA14-353A Lightweight Backdoor 6"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -20959,8 +20557,7 @@ rules:
       to_server: true
   - name: "sid:2020014"
     description: "ET MALWARE US-CERT TA14-353A Lightweight Backdoor 8"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -20970,8 +20567,7 @@ rules:
       established: true
   - name: "sid:2020015"
     description: "ET MALWARE US-CERT TA14-353A Lightweight Backdoor 9"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -20981,8 +20577,7 @@ rules:
       established: true
   - name: "sid:2020017"
     description: "ET MALWARE US-CERT TA14-353A Proxy Tool 1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -21057,8 +20652,7 @@ rules:
       to_server: true
   - name: "sid:2020389"
     description: "ET MALWARE Linux/Xnote Keep-Alive"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -21091,8 +20685,7 @@ rules:
       exact: 12
   - name: "sid:2020850"
     description: "ET MALWARE TinyLoader.B1 Checkin x64"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -21102,8 +20695,7 @@ rules:
       exact: 12
   - name: "sid:2020851"
     description: "ET MALWARE TinyLoader.B2 Checkin no architecture"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -21157,8 +20749,7 @@ rules:
       to_server: true
   - name: "sid:2022072"
     description: "ET MALWARE TinyLoader.B2 Checkin x64"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -21179,8 +20770,7 @@ rules:
       to_server: true
   - name: "sid:2022360"
     description: "ET MALWARE TrochilusRAT CnC Beacon 1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -21325,24 +20915,21 @@ rules:
       to_server: true
   - name: "sid:2024057"
     description: "ET SHELLCODE Linux/x86-64 - Polymorphic Flush IPTables Shellcode"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:jRX�Rfh\\-FT\\[RH�iptablesQ��\\(�H�//sbin//QT_RSWT\\^\u000f\u0005)"
       case_insensitive: false
   - name: "sid:2024058"
     description: "ET SHELLCODE Linux/x86-64 - Polymorphic Setuid(0) & Execve(/bin/sh) Shellcode"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:1�WjiXH�\\^���\\^\\^��\u000f\u0005H�˰;S��T�_\u000f\u0005)"
       case_insensitive: false
   - name: "sid:2024065"
     description: "ET SHELLCODE Linux/x86-64 - Reverse Shell Shellcode"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:j\u0002j\\*j\u0010j\\)j\u0001j\u0002).*?(?-i:H�//bin/sh)"
@@ -22223,8 +21810,7 @@ rules:
       to_server: true
   - name: "sid:2029042"
     description: "ET MALWARE ELF/Roboto - Communicating with Hardcoded Peer 1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -22234,8 +21820,7 @@ rules:
       exact: 69
   - name: "sid:2029043"
     description: "ET MALWARE ELF/Roboto - Communicating with Hardcoded Peer 2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -22245,8 +21830,7 @@ rules:
       exact: 69
   - name: "sid:2029044"
     description: "ET MALWARE ELF/Roboto - Communicating with Hardcoded Peer 3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -22256,8 +21840,7 @@ rules:
       exact: 69
   - name: "sid:2029045"
     description: "ET MALWARE ELF/Roboto - Communicating with Hardcoded Peer 4"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -22267,8 +21850,7 @@ rules:
       exact: 69
   - name: "sid:2029046"
     description: "ET MALWARE ELF/Roboto - Communicating with Hardcoded Peer 5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -22348,8 +21930,7 @@ rules:
       case_insensitive: false
   - name: "sid:2029136"
     description: "ET MALWARE AZORult v3.3 Server Response M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:\\?6�).{0,}(?-i:\\?z�=i�=)"
@@ -22359,8 +21940,7 @@ rules:
       to_client: true
   - name: "sid:2029137"
     description: "ET MALWARE AZORult v3.3 Server Response M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:\\?6�).{0,}(?-i:i�`k�mk)"
@@ -22370,8 +21950,7 @@ rules:
       to_client: true
   - name: "sid:2029138"
     description: "ET MALWARE AZORult v3.3 Server Response M3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:\\?6�).{0,}(?-i:�,6�\\?;�)"
@@ -22381,8 +21960,7 @@ rules:
       to_client: true
   - name: "sid:2029139"
     description: "ET MALWARE AZORult v3.2 Server Response M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:1i�).{0,}(?-i:1%�36�3)"
@@ -22392,8 +21970,7 @@ rules:
       to_client: true
   - name: "sid:2029140"
     description: "ET MALWARE AZORult v3.2 Server Response M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:1i�).{0,}(?-i:6�n4�c4)"
@@ -22403,8 +21980,7 @@ rules:
       to_client: true
   - name: "sid:2029141"
     description: "ET MALWARE AZORult v3.2 Server Response M3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:1i�).{0,}(?-i:�\"i�1d�)"
@@ -22803,8 +22379,7 @@ rules:
       to_server: true
   - name: "sid:2029330"
     description: "ET MALWARE Mimikatz x86 Executable Transfer Over SMB"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -22821,8 +22396,7 @@ rules:
         flag: "ET.smb.binary"
   - name: "sid:2029331"
     description: "ET MALWARE Mimikatz x64 Executable Transfer Over SMB"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -22839,8 +22413,7 @@ rules:
         flag: "ET.smb.binary"
   - name: "sid:2029332"
     description: "ET MALWARE Mimikatz x86 Mimidrv.sys File Transfer Over SMB"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -22857,8 +22430,7 @@ rules:
         flag: "ET.smb.binary"
   - name: "sid:2029333"
     description: "ET MALWARE Mimikatz x64 Mimidrv.sys File Transfer Over SMB"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -23848,8 +23420,7 @@ rules:
         flag: "ET.genericphish"
   - name: "sid:2046917"
     description: "ET MALWARE NanoCore RAT Keep-Alive Beacon (Inbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -30077,8 +29648,7 @@ rules:
       to_server: true
   - name: "sid:2013287"
     description: "ET MALWARE Papras Banking Trojan Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?i:POST).*?(?-i:N\\*C�\u0001�\\*w)"
@@ -30128,8 +29698,7 @@ rules:
       to_server: true
   - name: "sid:2013802"
     description: "ET MALWARE Cycbot POST"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?i:POST).*?(?-i:FILE0\u0000D0�qщSP)"
@@ -34212,8 +33781,7 @@ rules:
       to_client: true
   - name: "sid:2030006"
     description: "ET EXPLOIT Possible iOS MobileMail OOB Write/Heap Overflow Exploit Email (Inbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:AAAAAAAA).*?(?-i:AAAAATEy).*?(?-i:EA).*?(?-i:\\$\u000eΠ���\u0008).*?(?-i:T8hlGOo9).*?(?-i:OKl2N).*?(?-i:^(?:\\\\r\\\\n|\\x0d\\x0a)AABI).*?(?-i:^(?:\\\\r\\\\n|\\x0d\\x0a)C)"
@@ -35681,8 +35249,7 @@ rules:
       to_server: true
   - name: "sid:2021832"
     description: "ET MALWARE XcodeGhost CnC M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:\u0000\u0000\u0001).{1,20}(?-i:\u0000e\u0000\\\n�:\u0010�\\\t%Nה\\^�pY�y)"
@@ -35745,8 +35312,7 @@ rules:
       to_server: true
   - name: "sid:2030242"
     description: "ET EXPLOIT Possible Zephyr RTOS ICMPv4 Stack Buffer Overflow"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: icmp
     action: traffic_attack
     regex:
@@ -36373,8 +35939,7 @@ rules:
       to_server: true
   - name: "sid:2030348"
     description: "ET EXPLOIT AnyDesk UDP Discovery Format String (CVE-2020-13160)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -36868,8 +36433,7 @@ rules:
       to_server: true
   - name: "sid:2030478"
     description: "ET MALWARE SuperKillerX Checkin Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -36882,8 +36446,7 @@ rules:
       to_server: true
   - name: "sid:2030479"
     description: "ET MALWARE SuperKillerX CnC Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -36948,8 +36511,7 @@ rules:
       to_server: true
   - name: "sid:2030490"
     description: "ET MALWARE ELF/MooBot Mirai DDoS Variant CnC Checkin M1 (Group String Len 1)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -37145,8 +36707,7 @@ rules:
       to_server: true
   - name: "sid:2030532"
     description: "ET EXPLOIT Possible Windows DNS Integer Overflow Attempt M2 (CVE-2020-1350)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -37280,8 +36841,7 @@ rules:
       to_client: true
   - name: "sid:2026576"
     description: "ET MALWARE APT33/CharmingKitten Shellcode Communicating with CnC"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -38038,8 +37598,7 @@ rules:
       to_client: true
   - name: "sid:2024248"
     description: "ET MALWARE Possible DANDERSPRITZ HTTP Beacon"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i::0000).*?(?-i:�\u0000\u0000\u0000E�\u0011��D\u0000\u0000)"
@@ -39150,8 +38709,7 @@ rules:
       to_server: true
   - name: "sid:2012096"
     description: "ET SCADA DATAC RealWin SCADA Server Buffer Overflow"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -39225,8 +38783,7 @@ rules:
       to_server: true
   - name: "sid:2021111"
     description: "ET MALWARE DDoS.Win32/Nitol.B Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -39300,8 +38857,7 @@ rules:
       to_server: true
   - name: "sid:2027237"
     description: "ET RPC DCERPC SVCCTL - Remote Service Control Manager Access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -39532,8 +39088,7 @@ rules:
       to_server: true
   - name: "sid:2018560"
     description: "ET EXPLOIT SUSPICIOUS DTLS 1.0 Fragmented Client Hello Possible CVE-2014-0195"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -39560,8 +39115,7 @@ rules:
         no_case: false
   - name: "sid:2024382"
     description: "ET MALWARE DPRK HIDDEN COBRA DDoS Handshake Success"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -39574,8 +39128,7 @@ rules:
       to_server: true
   - name: "sid:2024383"
     description: "ET MALWARE DPRK HIDDEN COBRA Botnet C2 Host Beacon"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -39586,8 +39139,7 @@ rules:
       to_server: true
   - name: "sid:2024376"
     description: "ET EXPLOIT Win32/Industroyer DDOS Siemens SIPROTEC (CVE-2015-5374)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -39683,8 +39235,7 @@ rules:
       to_server: true
   - name: "sid:2029618"
     description: "ET EXPLOIT Zoho ManageEngine Desktop Central RCE Inbound (CVE-2020-10189)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:/mdm/client/v1/mdmLogUploader\\?udid=si\\\\\\.\\.\\\\\\.\\.\\\\\\.\\.\\\\webapps\\\\DesktopCentral\\\\_chart\\&filename=).*?(?-i:��\u0000\u0005sr\u0000\u0017java\\.util\\.PriorityQueue�)"
@@ -90456,8 +90007,7 @@ rules:
       to_server: true
   - name: "sid:2030924"
     description: "ET MALWARE Ttint XORed CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:GET).*?(?-i:Upgrade).*?(?-i:���\u0002��\u0004���\\\t��)"
@@ -90497,8 +90047,7 @@ rules:
       to_server: true
   - name: "sid:2030938"
     description: "ET MALWARE TA428 Tmanger Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -91755,8 +91304,7 @@ rules:
       to_server: true
   - name: "sid:2031009"
     description: "ET MALWARE StormKitty Data Exfil via Telegram"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:api\\.telegram\\.org).*?(?-i:/sendMessage\\?chat_id=).*?(?-i:text=\\\n).{0,}(?-i:\\ �).{0,}(?-i:\\*\\\nDate:\\ ).*?(?-i:\\\nSystem:\\ ).*?(?-i:\\ Bit\\)\\\nUsername:\\ )"
@@ -94321,8 +93869,7 @@ rules:
       to_server: true
   - name: "sid:2026500"
     description: "ET MALWARE Win32/Remcos RAT Checkin 60"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94333,8 +93880,7 @@ rules:
       to_server: true
   - name: "sid:2026018"
     description: "ET MALWARE Win32/Remcos RAT Checkin 28"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94345,8 +93891,7 @@ rules:
       to_server: true
   - name: "sid:2026503"
     description: "ET MALWARE Win32/Remcos RAT Checkin 63"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94357,8 +93902,7 @@ rules:
       to_server: true
   - name: "sid:2026507"
     description: "ET MALWARE Win32/Remcos RAT Checkin 67"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94369,8 +93913,7 @@ rules:
       to_server: true
   - name: "sid:2025637"
     description: "ET MALWARE Remcos RAT Checkin 23"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94381,8 +93924,7 @@ rules:
       to_server: true
   - name: "sid:2026498"
     description: "ET MALWARE Win32/Remcos RAT Checkin 58"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94393,8 +93935,7 @@ rules:
       to_server: true
   - name: "sid:2026502"
     description: "ET MALWARE Win32/Remcos RAT Checkin 62"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94405,8 +93946,7 @@ rules:
       to_server: true
   - name: "sid:2026020"
     description: "ET MALWARE Win32/Remcos RAT Checkin 30"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94417,8 +93957,7 @@ rules:
       to_server: true
   - name: "sid:2025984"
     description: "ET MALWARE [eSentire] Remcos RAT Checkin 25"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94429,8 +93968,7 @@ rules:
       to_server: true
   - name: "sid:2026495"
     description: "ET MALWARE Win32/Remcos RAT Checkin 55"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94441,8 +93979,7 @@ rules:
       to_server: true
   - name: "sid:2027660"
     description: "ET MALWARE Win32/Remcos RAT Checkin 109"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94453,8 +93990,7 @@ rules:
       to_server: true
   - name: "sid:2026019"
     description: "ET MALWARE Win32/Remcos RAT Checkin 29"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94465,8 +94001,7 @@ rules:
       to_server: true
   - name: "sid:2026496"
     description: "ET MALWARE Win32/Remcos RAT Checkin 56"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94477,8 +94012,7 @@ rules:
       to_server: true
   - name: "sid:2026017"
     description: "ET MALWARE Win32/Remcos RAT Checkin 27"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94489,8 +94023,7 @@ rules:
       to_server: true
   - name: "sid:2025921"
     description: "ET MALWARE [eSentire] Remcos RAT Checkin 24"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94501,8 +94034,7 @@ rules:
       to_server: true
   - name: "sid:2026499"
     description: "ET MALWARE Win32/Remcos RAT Checkin 59"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94513,8 +94045,7 @@ rules:
       to_server: true
   - name: "sid:2026501"
     description: "ET MALWARE Win32/Remcos RAT Checkin 61"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94525,8 +94056,7 @@ rules:
       to_server: true
   - name: "sid:2026494"
     description: "ET MALWARE Win32/Remcos RAT Checkin 54"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94537,8 +94067,7 @@ rules:
       to_server: true
   - name: "sid:2026497"
     description: "ET MALWARE Win32/Remcos RAT Checkin 57"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94549,8 +94078,7 @@ rules:
       to_server: true
   - name: "sid:2026016"
     description: "ET MALWARE Win32/Remcos RAT Checkin 26"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94561,8 +94089,7 @@ rules:
       to_server: true
   - name: "sid:2026504"
     description: "ET MALWARE Win32/Remcos RAT Checkin 64"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94573,8 +94100,7 @@ rules:
       to_server: true
   - name: "sid:2026901"
     description: "ET MALWARE Win32/Remcos RAT Checkin 84"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94585,8 +94111,7 @@ rules:
       to_server: true
   - name: "sid:2026506"
     description: "ET MALWARE Win32/Remcos RAT Checkin 66"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94597,8 +94122,7 @@ rules:
       to_server: true
   - name: "sid:2026508"
     description: "ET MALWARE Win32/Remcos RAT Checkin 68"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94609,8 +94133,7 @@ rules:
       to_server: true
   - name: "sid:2026505"
     description: "ET MALWARE Win32/Remcos RAT Checkin 65"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94811,8 +94334,7 @@ rules:
       to_server: true
   - name: "sid:2031192"
     description: "ET MALWARE Pay2Key Ransomware - Sending RSA Key"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -94983,8 +94505,7 @@ rules:
       case_insensitive: false
   - name: "sid:2027506"
     description: "ET MALWARE Win32/Plurox Backdoor CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -95092,8 +94613,7 @@ rules:
       to_server: true
   - name: "sid:2029839"
     description: "ET MALWARE ELF Linux/Dnsamp.AB Variant CnC"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -95143,8 +94663,7 @@ rules:
       to_server: true
   - name: "sid:2030143"
     description: "ET MALWARE MSIL/Modi RAT CnC Screenshot Outbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -96218,8 +95737,7 @@ rules:
       to_client: true
   - name: "sid:2031288"
     description: "ET CURRENT_EVENTS [Fireeye] HackTool.TCP.Rubeus.[nonce 2]"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -96230,8 +95748,7 @@ rules:
       case_insensitive: false
   - name: "sid:2031295"
     description: "ET CURRENT_EVENTS [Fireeye] HackTool.UDP.Rubeus.[nonce 2]"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -96282,8 +95799,7 @@ rules:
       case_insensitive: false
   - name: "sid:2031301"
     description: "ET CURRENT_EVENTS [Fireeye] M.HackTool.SMB.Impacket-Obfuscation.[Service Names] M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -96294,8 +95810,7 @@ rules:
       case_insensitive: false
   - name: "sid:2031300"
     description: "ET CURRENT_EVENTS [Fireeye] M.HackTool.SMB.Impacket-Obfuscation.[Service Names] M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -96306,8 +95821,7 @@ rules:
       case_insensitive: false
   - name: "sid:2031302"
     description: "ET CURRENT_EVENTS [Fireeye] M.HackTool.SMB.Impacket-Obfuscation.[Service Names] M3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -96318,8 +95832,7 @@ rules:
       case_insensitive: false
   - name: "sid:2031303"
     description: "ET CURRENT_EVENTS [Fireeye] M.HackTool.SMB.Impacket-Obfuscation.[Service Names] M4"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -96330,8 +95843,7 @@ rules:
       case_insensitive: false
   - name: "sid:2031304"
     description: "ET CURRENT_EVENTS [Fireeye] M.HackTool.SMB.Impacket-Obfuscation.[Service Names] M5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -96342,8 +95854,7 @@ rules:
       case_insensitive: false
   - name: "sid:2031305"
     description: "ET CURRENT_EVENTS [Fireeye] M.HackTool.SMB.Impacket-Obfuscation.[Service Names] M6"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -96354,8 +95865,7 @@ rules:
       case_insensitive: false
   - name: "sid:2031306"
     description: "ET CURRENT_EVENTS [Fireeye] M.HackTool.SMB.Impacket-Obfuscation.[Service Names] M7"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -96366,8 +95876,7 @@ rules:
       case_insensitive: false
   - name: "sid:2031307"
     description: "ET CURRENT_EVENTS [Fireeye] M.HackTool.SMB.Impacket-Obfuscation.[Service Names] M8"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -96378,8 +95887,7 @@ rules:
       case_insensitive: false
   - name: "sid:2031308"
     description: "ET CURRENT_EVENTS [Fireeye] M.HackTool.SMB.Impacket-Obfuscation.[Service Names] M9"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -96418,8 +95926,7 @@ rules:
       case_insensitive: false
   - name: "sid:2031265"
     description: "ET CURRENT_EVENTS [Fireeye] Backdoor.DNS.BEACON.[CSBundle DNS]"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,4}(?-i:\u0000\u0001\u0000\u0001).{0,15}(?-i:\u0003).{3,11}(?-i:\\\n_domainkey).*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001\u0000\u0000\u0000\u0002\u0001\u0000�v=DKIM1\\\\;\\ p=)"
@@ -97064,8 +96571,7 @@ rules:
       to_client: true
   - name: "sid:2022337"
     description: "ET MALWARE Win32.Nitol.K Variant CnC"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -98015,8 +97521,7 @@ rules:
       to_server: true
   - name: "sid:2031937"
     description: "ET EXPLOIT Possible NSDP (Netgear) Remote Authentication Bypass with Factory Reset (CVE-2020-35231)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -98029,8 +97534,7 @@ rules:
       exact: 13
   - name: "sid:2031938"
     description: "ET EXPLOIT Possible NSDP (Netgear) Unauthenticated Buffer Overflow (CVE-2020-35232)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -98043,8 +97547,7 @@ rules:
       min: 17
   - name: "sid:2031940"
     description: "ET EXPLOIT Possible NSDP (Netgear) Unauthenticated Write Access to DHCP Config (CVE-2020-35226)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -98075,8 +97578,7 @@ rules:
       to_server: true
   - name: "sid:2031943"
     description: "ET EXPLOIT Possible NSDP (Netgear) Write Command Buffer Overflow Attempt - 0x0003 (CVE-2020-35225)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -98087,8 +97589,7 @@ rules:
       case_insensitive: false
   - name: "sid:2031944"
     description: "ET EXPLOIT Possible NSDP (Netgear) Write Command Buffer Overflow Attempt - 0x0005 (CVE-2020-35225)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -98099,8 +97600,7 @@ rules:
       case_insensitive: false
   - name: "sid:2031945"
     description: "ET EXPLOIT Possible NSDP (Netgear) Write Command Buffer Overflow Attempt - 0x000a (CVE-2020-35225)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -98993,8 +98493,7 @@ rules:
       to_client: true
   - name: "sid:2032776"
     description: "ET MALWARE Remcos 3.x Unencrypted Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -99005,8 +98504,7 @@ rules:
       to_server: true
   - name: "sid:2032777"
     description: "ET MALWARE Remcos 3.x Unencrypted Server Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -99135,8 +98633,7 @@ rules:
       to_server: true
   - name: "sid:2032807"
     description: "ET MALWARE MSIL/MosaiqueRAT CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -99782,8 +99279,7 @@ rules:
       to_server: true
   - name: "sid:2033108"
     description: "ET MALWARE zgRAT Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -100026,8 +99522,7 @@ rules:
       to_server: true
   - name: "sid:2033005"
     description: "ET MALWARE Win32/SystemBC CnC Checkin (null key) M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -100040,8 +99535,7 @@ rules:
       to_server: true
   - name: "sid:2033004"
     description: "ET MALWARE Win32/SystemBC CnC Checkin (null key) M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -100328,8 +99822,7 @@ rules:
       to_server: true
   - name: "sid:2033093"
     description: "ET MALWARE FatalRAT CnC Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -100637,8 +100130,7 @@ rules:
     private: true
   - name: "sid:2033212"
     description: "ET MALWARE zgRAT Activity M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -100776,8 +100268,7 @@ rules:
       case_insensitive: false
   - name: "sid:2033237"
     description: "ET MALWARE Mirai pTea Variant - Initial CnC Checkin Outbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -100790,8 +100281,7 @@ rules:
       to_server: true
   - name: "sid:2033238"
     description: "ET MALWARE Mirai pTea Variant - Initial CnC Checkin Inbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -100804,8 +100294,7 @@ rules:
       to_server: true
   - name: "sid:2033240"
     description: "ET MALWARE Mirai pTea Variant - Info Submission Outbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -100818,8 +100307,7 @@ rules:
       to_server: true
   - name: "sid:2033241"
     description: "ET MALWARE Mirai pTea Variant - Info Submission Inbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -101163,8 +100651,7 @@ rules:
       to_client: true
   - name: "sid:2033255"
     description: "ET INFO [MS-PAR] Windows Printer Spooler Activity - RpcAsyncAddPrinterDriver"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -101178,8 +100665,7 @@ rules:
       to_server: true
   - name: "sid:2033263"
     description: "ET INFO [MS-PAR] Windows Printer Spooler Activity - RpcAsyncCorePrinterDriverInstalled"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -101193,8 +100679,7 @@ rules:
       to_server: true
   - name: "sid:2033258"
     description: "ET INFO [MS-PAR] Windows Printer Spooler Activity - RpcAsyncDeletePrinterDriver"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -101208,8 +100693,7 @@ rules:
       to_server: true
   - name: "sid:2033259"
     description: "ET INFO [MS-PAR] Windows Printer Spooler Activity - RpcAsyncDeletePrinterDriverEx"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -101223,8 +100707,7 @@ rules:
       to_server: true
   - name: "sid:2033265"
     description: "ET INFO [MS-PAR] Windows Printer Spooler Activity - RpcAsyncDeletePrinterDriverPackage"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -101238,8 +100721,7 @@ rules:
       to_server: true
   - name: "sid:2033254"
     description: "ET INFO [MS-PAR] Windows Printer Spooler Activity - RpcAsyncEnumPrinterDrivers"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -101253,8 +100735,7 @@ rules:
       to_server: true
   - name: "sid:2033262"
     description: "ET INFO [MS-PAR] Windows Printer Spooler Activity - RpcAsyncGetCorePrinterDrivers"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -101268,8 +100749,7 @@ rules:
       to_server: true
   - name: "sid:2033256"
     description: "ET INFO [MS-PAR] Windows Printer Spooler Activity - RpcAsyncGetPrinterDriver"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -101283,8 +100763,7 @@ rules:
       to_server: true
   - name: "sid:2033257"
     description: "ET INFO [MS-PAR] Windows Printer Spooler Activity - RpcAsyncGetPrinterDriverDirectory"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -101298,8 +100777,7 @@ rules:
       to_server: true
   - name: "sid:2033264"
     description: "ET INFO [MS-PAR] Windows Printer Spooler Activity - RpcAsyncGetPrinterDriverPackagePath"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -101320,8 +100798,7 @@ rules:
       case_insensitive: false
   - name: "sid:2033332"
     description: "ET MALWARE MargulasRAT Checkin M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -101332,8 +100809,7 @@ rules:
       to_server: true
   - name: "sid:2033333"
     description: "ET MALWARE MargulasRAT Keep-Alive Outbound M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -101346,8 +100822,7 @@ rules:
       to_server: true
   - name: "sid:2033334"
     description: "ET MALWARE MargulasRAT Keep-Alive Inbound M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -101358,8 +100833,7 @@ rules:
       to_client: true
   - name: "sid:2033335"
     description: "ET MALWARE MargulasRAT Checkin M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -101370,8 +100844,7 @@ rules:
       to_server: true
   - name: "sid:2033336"
     description: "ET MALWARE MargulasRAT Keep-Alive Outbound M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -101384,8 +100857,7 @@ rules:
       to_server: true
   - name: "sid:2033337"
     description: "ET MALWARE MargulasRAT Keep-Alive Inbound M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -101582,8 +101054,7 @@ rules:
       to_server: true
   - name: "sid:2033261"
     description: "ET INFO [MS-PAR] Windows Printer Spooler Activity - RpcAsyncUploadPrinterDriverPackage"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -101597,8 +101068,7 @@ rules:
       to_server: true
   - name: "sid:2033260"
     description: "ET INFO [MS-PAR] Windows Printer Spooler Activity - RpcAsyncInstallPrinterDriverFromPackage"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -101652,8 +101122,7 @@ rules:
       to_server: true
   - name: "sid:2030491"
     description: "ET MALWARE ELF/MooBot Mirai DDoS Variant CnC Checkin M2 (Group String Len 2+)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -101882,8 +101351,7 @@ rules:
       to_server: true
   - name: "sid:2033430"
     description: "ET HUNTING NOP Sled in HTTP Header Inbound - Possible Exploit Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�����������)"
@@ -103179,8 +102647,7 @@ rules:
       to_server: true
   - name: "sid:2033605"
     description: "ET EXPLOIT TIBCO Data Virtualization <= 8.3 RCE Attempt (CVE-2016-2510)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?i:POST).*?(?i:/monitor/messagebroker/amf).*?(?-i:\u0000\u0003\u0000\u0000\u0000\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001\u0011\\\n\u0007Gorg\\.apache\\.axis2\\.util\\.MetaDataEntry\\|����O��\u0000\u0000\u0000\u0002\u0001\u0000\u0000\u0000)"
@@ -103190,8 +102657,7 @@ rules:
       to_server: true
   - name: "sid:2033606"
     description: "ET WEB_SPECIFIC_APPS Possible MobileIron MDM RCE Inbound (CVE-2020-15505)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:/mifs/\\.;/).*?(?-i:c\u0002\u0000H\u0000�).*?(?-i:B\u0000e\u0000a\u0000n\u0000F\u0000a\u0000c\u0000).{0,}(?-i:r\u0000m\u0000i\u0000:\u0000/\u0000/)"
@@ -103578,8 +103044,7 @@ rules:
       to_server: true
   - name: "sid:2033737"
     description: "ET MALWARE DarkWay Client Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -103663,8 +103128,7 @@ rules:
       to_server: true
   - name: "sid:2020019"
     description: "ET MALWARE US-CERT TA14-353A Proxy Tool 3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -103805,8 +103269,7 @@ rules:
       to_server: true
   - name: "sid:2033819"
     description: "ET MALWARE Win32/GenCBL.XS CnC Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104000,8 +103463,7 @@ rules:
       to_server: true
   - name: "sid:2020780"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 79"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104014,8 +103476,7 @@ rules:
       to_server: true
   - name: "sid:2020770"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 69"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104028,8 +103489,7 @@ rules:
       to_server: true
   - name: "sid:2020773"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 72"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104042,8 +103502,7 @@ rules:
       to_server: true
   - name: "sid:2020786"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 85"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104056,8 +103515,7 @@ rules:
       to_server: true
   - name: "sid:2019083"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 41"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104070,8 +103528,7 @@ rules:
       to_server: true
   - name: "sid:2020789"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 88"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104084,8 +103541,7 @@ rules:
       to_server: true
   - name: "sid:2017916"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 10"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104098,8 +103554,7 @@ rules:
       to_server: true
   - name: "sid:2018880"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 40"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104112,8 +103567,7 @@ rules:
       to_server: true
   - name: "sid:2018166"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 28"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104126,8 +103580,7 @@ rules:
       to_server: true
   - name: "sid:2020775"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 74"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104166,8 +103619,7 @@ rules:
       to_server: true
   - name: "sid:2020607"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 48"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104180,8 +103632,7 @@ rules:
       to_server: true
   - name: "sid:2020788"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 87"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104194,8 +103645,7 @@ rules:
       to_server: true
   - name: "sid:2020696"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 61"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104208,8 +103658,7 @@ rules:
       to_server: true
   - name: "sid:2020614"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 55"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104222,8 +103671,7 @@ rules:
       to_server: true
   - name: "sid:2018032"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 19"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104246,8 +103694,7 @@ rules:
       to_server: true
   - name: "sid:2030489"
     description: "ET MALWARE ELF/MooBot Mirai DDoS Variant Server Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104260,8 +103707,7 @@ rules:
       to_client: true
   - name: "sid:2020771"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 70"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104274,8 +103720,7 @@ rules:
       to_server: true
   - name: "sid:2020767"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 66"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104288,8 +103733,7 @@ rules:
       to_server: true
   - name: "sid:2017913"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 7"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104302,8 +103746,7 @@ rules:
       to_server: true
   - name: "sid:2020764"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 63"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104316,8 +103759,7 @@ rules:
       to_server: true
   - name: "sid:2020769"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 68"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104330,8 +103772,7 @@ rules:
       to_server: true
   - name: "sid:2020606"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 47"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104390,8 +103831,7 @@ rules:
       to_server: true
   - name: "sid:2033894"
     description: "ET EXPLOIT Possible SolarWinds Serv-U SSH RCE Inbound M2 (CVE-2021-35211)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -104407,8 +103847,7 @@ rules:
       to_server: true
   - name: "sid:2018085"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 26"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104421,8 +103860,7 @@ rules:
       to_server: true
   - name: "sid:2017707"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 4"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104435,8 +103873,7 @@ rules:
       to_server: true
   - name: "sid:2018153"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 27"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104449,8 +103886,7 @@ rules:
       to_server: true
   - name: "sid:2020611"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 52"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104463,8 +103899,7 @@ rules:
       to_server: true
   - name: "sid:2018638"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 38"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104477,8 +103912,7 @@ rules:
       to_server: true
   - name: "sid:2020799"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 98"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104491,8 +103925,7 @@ rules:
       to_server: true
   - name: "sid:2017934"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 11"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104515,8 +103948,7 @@ rules:
       to_server: true
   - name: "sid:2018287"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 31"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104529,8 +103961,7 @@ rules:
       to_server: true
   - name: "sid:2020794"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 93"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104543,8 +103974,7 @@ rules:
       to_server: true
   - name: "sid:2018485"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 32"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104707,8 +104137,7 @@ rules:
         no_case: false
   - name: "sid:2018486"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 33"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104740,8 +104169,7 @@ rules:
       to_server: true
   - name: "sid:2020763"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 62"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104754,8 +104182,7 @@ rules:
       to_server: true
   - name: "sid:2020693"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 58"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104768,8 +104195,7 @@ rules:
       to_server: true
   - name: "sid:2020766"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 65"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104782,8 +104208,7 @@ rules:
       to_server: true
   - name: "sid:2020798"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 97"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104796,8 +104221,7 @@ rules:
       to_server: true
   - name: "sid:2020371"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 45"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104810,8 +104234,7 @@ rules:
       to_server: true
   - name: "sid:2020796"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 95"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104824,8 +104247,7 @@ rules:
       to_server: true
   - name: "sid:2017915"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 9"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104838,8 +104260,7 @@ rules:
       to_server: true
   - name: "sid:2018057"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 21"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104852,8 +104273,7 @@ rules:
       to_server: true
   - name: "sid:2018636"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 36"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104866,8 +104286,7 @@ rules:
       to_server: true
   - name: "sid:2020790"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 89"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104880,8 +104299,7 @@ rules:
       to_server: true
   - name: "sid:2020787"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 86"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104894,8 +104312,7 @@ rules:
       to_server: true
   - name: "sid:2020781"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 80"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104908,8 +104325,7 @@ rules:
       to_server: true
   - name: "sid:2018054"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 20"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104922,8 +104338,7 @@ rules:
       to_server: true
   - name: "sid:2020609"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 50"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104936,8 +104351,7 @@ rules:
       to_server: true
   - name: "sid:2020691"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 56"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104950,8 +104364,7 @@ rules:
       to_server: true
   - name: "sid:2020778"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 77"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104964,8 +104377,7 @@ rules:
       to_server: true
   - name: "sid:2017876"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104978,8 +104390,7 @@ rules:
       to_server: true
   - name: "sid:2017877"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 6"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -104992,8 +104403,7 @@ rules:
       to_server: true
   - name: "sid:2017944"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 14"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105006,8 +104416,7 @@ rules:
       to_server: true
   - name: "sid:2020586"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 46"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105020,8 +104429,7 @@ rules:
       to_server: true
   - name: "sid:2020783"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 82"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105034,8 +104442,7 @@ rules:
       to_server: true
   - name: "sid:2020793"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 92"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105061,8 +104468,7 @@ rules:
       to_server: true
   - name: "sid:2018488"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 35"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105094,8 +104500,7 @@ rules:
       to_server: true
   - name: "sid:2020765"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 64"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105108,8 +104513,7 @@ rules:
       to_server: true
   - name: "sid:2020610"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 51"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105122,8 +104526,7 @@ rules:
       to_server: true
   - name: "sid:2020782"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 81"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105136,8 +104539,7 @@ rules:
       to_server: true
   - name: "sid:2017988"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 16"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105169,8 +104571,7 @@ rules:
       to_server: true
   - name: "sid:2020800"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 99"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105183,8 +104584,7 @@ rules:
       to_server: true
   - name: "sid:2020797"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 96"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105197,8 +104597,7 @@ rules:
       to_server: true
   - name: "sid:2018637"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 37"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105211,8 +104610,7 @@ rules:
       to_server: true
   - name: "sid:2020692"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 57"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105225,8 +104623,7 @@ rules:
       to_server: true
   - name: "sid:2020772"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 71"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105239,8 +104636,7 @@ rules:
       to_server: true
   - name: "sid:2020695"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 60"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105253,8 +104649,7 @@ rules:
       to_server: true
   - name: "sid:2020694"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 59"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105267,8 +104662,7 @@ rules:
       to_server: true
   - name: "sid:2018639"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 39"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105281,8 +104675,7 @@ rules:
       to_server: true
   - name: "sid:2018013"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 18"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105295,8 +104688,7 @@ rules:
       to_server: true
   - name: "sid:2019602"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 43"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105309,8 +104701,7 @@ rules:
       to_server: true
   - name: "sid:2018076"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 24"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105323,8 +104714,7 @@ rules:
       to_server: true
   - name: "sid:2020768"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 67"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105337,8 +104727,7 @@ rules:
       to_server: true
   - name: "sid:2020785"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 84"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105351,8 +104740,7 @@ rules:
       to_server: true
   - name: "sid:2020608"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 49"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105365,8 +104753,7 @@ rules:
       to_server: true
   - name: "sid:2020613"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 54"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105392,8 +104779,7 @@ rules:
       to_server: true
   - name: "sid:2018487"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 34"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105425,8 +104811,7 @@ rules:
       to_server: true
   - name: "sid:2017938"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 13"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105456,8 +104841,7 @@ rules:
       to_server: true
   - name: "sid:2018069"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 22"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105470,8 +104854,7 @@ rules:
       to_server: true
   - name: "sid:2020612"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 53"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105484,8 +104867,7 @@ rules:
       to_server: true
   - name: "sid:2020777"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 76"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105498,8 +104880,7 @@ rules:
       to_server: true
   - name: "sid:2020784"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 83"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105512,8 +104893,7 @@ rules:
       to_server: true
   - name: "sid:2017914"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 8"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105526,8 +104906,7 @@ rules:
       to_server: true
   - name: "sid:2018181"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 29"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105559,8 +104938,7 @@ rules:
       to_server: true
   - name: "sid:2016922"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105573,8 +104951,7 @@ rules:
       to_server: true
   - name: "sid:2018075"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 23"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105587,8 +104964,7 @@ rules:
       to_server: true
   - name: "sid:2020214"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 44"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105601,8 +104977,7 @@ rules:
       to_server: true
   - name: "sid:2020795"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 94"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -105821,8 +105196,7 @@ rules:
       case_insensitive: false
   - name: "sid:2033985"
     description: "ET EXPLOIT JBOSS Deserialization Attempt Inbound (CVE-2017-7504)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:/jbossmq\\-httpil/HTTPServerILServlet).*?(?-i:��\u0000)"
@@ -105852,8 +105226,7 @@ rules:
       to_client: true
   - name: "sid:2033992"
     description: "ET MALWARE NSIS/TrojanDownloader.Agent.NZK Server Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�����Ș�).*?(?-i:��).*?(?-i:��)"
@@ -106238,8 +105611,7 @@ rules:
       to_client: true
   - name: "sid:2034236"
     description: "ET MALWARE Win32/Remcos RAT Checkin 756"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -106381,8 +105753,7 @@ rules:
       case_insensitive: false
   - name: "sid:2034193"
     description: "ET MALWARE Win32/Agent.RTQ CnC Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -106609,8 +105980,7 @@ rules:
       to_server: true
   - name: "sid:2034254"
     description: "ET MALWARE Win32/WinDealer CnC Activity (Checkin)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -106790,8 +106160,7 @@ rules:
       to_server: true
   - name: "sid:2034275"
     description: "ET MALWARE Win32.Application.ThunderN.A Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -106802,8 +106171,7 @@ rules:
       to_server: true
   - name: "sid:2034301"
     description: "ET MALWARE Win32/Small.NO Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -107289,8 +106657,7 @@ rules:
       to_server: true
   - name: "sid:2035632"
     description: "ET MALWARE Win32/Farfli.CUY KeepAlive M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -107635,8 +107002,7 @@ rules:
       to_server: true
   - name: "sid:2034557"
     description: "ET MALWARE W32.DarkVNC Variant Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -108456,8 +107822,7 @@ rules:
     private: true
   - name: "sid:2034722"
     description: "ET ATTACK_RESPONSE Possible CVE-2021-44228 Payload via LDAPv3 Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -108513,8 +107878,7 @@ rules:
       case_insensitive: false
   - name: "sid:2034720"
     description: "ET INFO Successful LDAPSv3 LDAPS_START_TLS Request Outbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -108870,8 +108234,7 @@ rules:
       to_server: true
   - name: "sid:2034769"
     description: "ET ATTACK_RESPONSE Possible CVE-2021-44228 Payload via LDAPv3 Response M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -108951,8 +108314,7 @@ rules:
         flag: "ET.LDAPBindRequest"
   - name: "sid:2034818"
     description: "ET INFO Serialized Java Object returned via LDAPv3 Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -109282,8 +108644,7 @@ rules:
       to_server: true
   - name: "sid:2034873"
     description: "ET MALWARE PurpleFox Backdoor/Rootkit Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -109469,8 +108830,7 @@ rules:
       to_server: true
   - name: "sid:2034908"
     description: "ET ADWARE_PUP Win32/Hao123.C Variant CnC Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:multipart/form\\-data;\\ boundary=).*?(?-i:Content\\-Disposition:\\ form\\-data;\\ name=\"ufile01\";\\ filename=\"boundary\"\\\r\\\nContent\\-Type:\\ application/octet\\-stream\\\r\\\n\\\r\\\n/x�\u0005g)"
@@ -109480,8 +108840,7 @@ rules:
       to_server: true
   - name: "sid:2034909"
     description: "ET MALWARE APT/Bitter Related CnC Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -110292,8 +109651,7 @@ rules:
       to_client: true
   - name: "sid:2035204"
     description: "ET EXPLOIT Oracle Weblogic Server Deserialization RCE T3 (CVE-2015-4852)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -110979,8 +110337,7 @@ rules:
       to_client: true
   - name: "sid:2026040"
     description: "ET MALWARE CobaltStrike DNS Beacon Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -111031,8 +110388,7 @@ rules:
       to_server: true
   - name: "sid:2036734"
     description: "ET MALWARE Ave Maria/Warzone RAT Encrypted CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -111084,8 +110440,7 @@ rules:
       case_insensitive: false
   - name: "sid:2035415"
     description: "ET MALWARE SoulSearcher Checkin M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     domain:
       domains: ["/msn-msn/log/2/debug?tim="]
@@ -111098,8 +110453,7 @@ rules:
       to_server: true
   - name: "sid:2035416"
     description: "ET MALWARE SoulSearcher Checkin M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     domain:
       domains: ["/en-my/CMSStyles/style.csx?k="]
@@ -111123,8 +110477,7 @@ rules:
       to_server: true
   - name: "sid:2035423"
     description: "ET MALWARE HermeticWizard - WMI Spreader - File Copy via SMB1 (NT Create AndX Request)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -111190,8 +110543,7 @@ rules:
       to_server: true
   - name: "sid:2035437"
     description: "ET MALWARE HermeticWizard - SMB Spreader - File Copy via SMB1 (NT Create AndX Request)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -111219,8 +110571,7 @@ rules:
       to_server: true
   - name: "sid:2035441"
     description: "ET MALWARE Successful Cobalt Strike Shellcode Download (x32)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:��\u0000\u0000\u0000`��1�d�R0�R\\\u000c�)"
@@ -111230,8 +110581,7 @@ rules:
       to_client: true
   - name: "sid:2035442"
     description: "ET MALWARE Successful Cobalt Strike Shellcode Download (x64) M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:�H����3\\]�E\u0000H��\u0004�)"
@@ -111241,8 +110591,7 @@ rules:
       to_client: true
   - name: "sid:2035443"
     description: "ET MALWARE Successful Cobalt Strike Shellcode Download (x64) M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:�H�����\u0000\u0000\u0000AQAP)"
@@ -111252,8 +110601,7 @@ rules:
       to_client: true
   - name: "sid:2035438"
     description: "ET MALWARE Win32/Remcos RAT Checkin 781"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -111402,8 +110750,7 @@ rules:
       to_server: true
   - name: "sid:2035467"
     description: "ET INFO Remote Desktop AeroAdmin handshake"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -111499,8 +110846,7 @@ rules:
       to_client: true
   - name: "sid:2035474"
     description: "ET MALWARE SideCopy APT MargulasRAT Related Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -111882,8 +111228,7 @@ rules:
       case_insensitive: false
   - name: "sid:2035533"
     description: "ET MALWARE Bitter APT Backdoor Related Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -111927,8 +111272,7 @@ rules:
       to_client: true
   - name: "sid:2035527"
     description: "ET MALWARE Linux/B1txor20 Backdoor DNS Tunnel Activity M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001\u0000\u0000\u0000\u0001).{1,3}(?-i:1).{2,6}(?-i:E6NZwc)"
@@ -111945,8 +111289,7 @@ rules:
         no_case: false
   - name: "sid:2035528"
     description: "ET MALWARE Linux/B1txor20 Backdoor DNS Tunnel Activity M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001\u0000\u0000\u0000\u0001).{1,3}(?-i:1).{2,6}(?-i:E6NZzH)"
@@ -111963,8 +111306,7 @@ rules:
         no_case: false
   - name: "sid:2035529"
     description: "ET MALWARE Linux/B1txor20 Backdoor DNS Tunnel Activity M3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001\u0000\u0000\u0000\u0001).{1,3}(?-i:1).{2,6}(?-i:E6NZxA)"
@@ -112144,8 +111486,7 @@ rules:
       to_client: true
   - name: "sid:2019922"
     description: "ET EXPLOIT Possible GoldenPac Priv Esc in-use"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -112159,8 +111500,7 @@ rules:
       to_server: true
   - name: "sid:2027361"
     description: "ET MALWARE Winnti Payload - XORed Check-in to Infected System (0xd4413890)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -113260,8 +112600,7 @@ rules:
       case_insensitive: false
   - name: "sid:2035752"
     description: "ET MALWARE Win32/Agent.USB Variant CnC Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -113512,8 +112851,7 @@ rules:
       to_client: true
   - name: "sid:2035880"
     description: "ET MALWARE Win32/Farfli.CUY KeepAlive M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -113554,8 +112892,7 @@ rules:
       to_server: true
   - name: "sid:2035887"
     description: "ET EXPLOIT Possible OpenSSL Infinite Loop Inducing Cert Inbound via TCP (CVE-2022-0778)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -113566,8 +112903,7 @@ rules:
       to_server: true
   - name: "sid:2035888"
     description: "ET EXPLOIT Possible OpenSSL Infinite Loop Inducing Cert Inbound via UDP (CVE-2022-0778)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -113665,8 +113001,7 @@ rules:
       to_server: true
   - name: "sid:2025702"
     description: "ET INFO SMB NT Create AndX Request For an Executable File In a Temp Directory"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -113720,8 +113055,7 @@ rules:
       to_server: true
   - name: "sid:2036215"
     description: "ET MOBILE_MALWARE Trojan-Banker.AndroidOS.Wroba Lure (Package Delivery)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -113732,8 +113066,7 @@ rules:
       to_client: true
   - name: "sid:2035940"
     description: "ET MALWARE Fodcha Bot CnC Client Heartbeat"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -113746,8 +113079,7 @@ rules:
       to_client: true
   - name: "sid:2035941"
     description: "ET MALWARE Fodcha Bot CnC Heartbeat Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -113824,8 +113156,7 @@ rules:
       to_server: true
   - name: "sid:2026433"
     description: "ET MALWARE [PTsecurity] Win32/Remcos RAT Checkin 51"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -115393,8 +114724,7 @@ rules:
       to_server: true
   - name: "sid:2036867"
     description: "ET MALWARE Win32/SVCReady Loader - Screenshot"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:\\{\"method\":\"screenshot\",\"params\":).{0,}(?-i:,\"stage\":\"init\").{0,}(?-i:�PNG\\\r\\\n)"
@@ -115511,8 +114841,7 @@ rules:
       to_server: true
   - name: "sid:2036650"
     description: "ET EXPLOIT Default Apache CouchDB Erlang Cookie Observed (CVE-2022-24706)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -115576,8 +114905,7 @@ rules:
       to_server: true
   - name: "sid:2036690"
     description: "ET INFO Possible JARM Fingerprinting Client Hello via tls1_2_forward"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0016\u00003\u0000g����\u0000�\u00009\u0000k����\u0000�\u0000E\u0000�\u0000�\u0000�\u0000��\u0008�\\\t�\\#�����\\+�\\\n�\\$�����,�r�s̩\u0013\u0002\u0013\u0001�\u0014�\u0007�\u0012�\u0013�'�/�\u0014�\\(�0�`�a�v�w̨\u0013\u0005\u0013\u0004\u0013\u0003�\u0013�\u0011\u0000\\\n\u0000/\u0000<����\u0000�\u00005\u0000=����\u0000�\u0000A\u0000�\u0000�\u0000�\u0000\u0007\u0000\u0004\u0000\u0005).*?(?-i:\u0002hq\u0003h2c\u0002h2\u0006spdy/3\u0006spdy/2\u0006spdy/1\u0008http/1\\.1\u0008http/1\\.0\u0008http/0\\.9).*?(?-i:\u0003\u0003\u0003\u0002\u0003\u0001)"
@@ -115587,8 +114915,7 @@ rules:
       to_client: true
   - name: "sid:2036691"
     description: "ET INFO Possible JARM Fingerprinting Client Hello via tls1_2_reverse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0016\u0003\u0003).*?(?-i:\u0000\u0005\u0000\u0004\u0000\u0007\u0000�\u0000�\u0000�\u0000A\u0000�����\u0000=\u00005\u0000�����\u0000<\u0000/\u0000\\\n�\u0011�\u0013\u0013\u0003\u0013\u0004\u0013\u0005̨�w�v�a�`�0�\\(�\u0014�/�'�\u0013�\u0012�\u0007�\u0014\u0013\u0001\u0013\u0002̩�s�r�,�����\\$�\\\n�\\+�����\\#�\\\t�\u0008\u0000�\u0000�\u0000�\u0000�\u0000E\u0000�����\u0000k\u00009\u0000�����\u0000g\u00003\u0000\u0016).*?(?-i:\u0008http/0\\.9\u0008http/1\\.0\u0008http/1\\.1\u0006spdy/1\u0006spdy/2\u0006spdy/3\u0002h2\u0003h2c\u0002hq).*?(?-i:\u0003\u0001\u0003\u0002\u0003\u0003)"
@@ -115598,8 +114925,7 @@ rules:
       to_client: true
   - name: "sid:2036692"
     description: "ET INFO Possible JARM Fingerprinting Client Hello via tls1_2_top_half"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�\u0012�\u0007�\u0014\u0013\u0001\u0013\u0002̩�s�r�,�����\\$�\\\n�\\+�����\\#�\\\t�\u0008\u0000�\u0000�\u0000�\u0000�\u0000E\u0000�����\u0000k\u00009\u0000�����\u0000g\u00003\u0000\u0016).*?(?-i:\u0008http/0\\.9\u0008http/1\\.0\u0008http/1\\.1\u0006spdy/1\u0006spdy/2\u0006spdy/3\u0002h2\u0003h2c\u0002hq)"
@@ -115609,8 +114935,7 @@ rules:
       to_client: true
   - name: "sid:2036693"
     description: "ET INFO Possible JARM Fingerprinting Client Hello via tls1_2_bottom_half"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�\u0013�'�/�\u0014�\\(�0�`�a�v�w̨\u0013\u0005\u0013\u0004\u0013\u0003�\u0013�\u0011\u0000\\\n\u0000/\u0000<����\u0000�\u00005\u0000=����\u0000�\u0000A\u0000�\u0000�\u0000�\u0000\u0007\u0000\u0004\u0000\u0005).*?(?-i:\u0008http/0\\.9\u0008http/1\\.0\u0006spdy/1\u0006spdy/2\u0006spdy/3\u0003h2c\u0002hq)"
@@ -115620,8 +114945,7 @@ rules:
       to_client: true
   - name: "sid:2036694"
     description: "ET INFO Possible JARM Fingerprinting Client Hello via tls1_2_middle_out"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�\u0012�\u0013�\u0007�'�\u0014�/\u0013\u0001�\u0014\u0013\u0002�\\(̩�0�s�`�r�a�,�v���w��̨�\\$\u0013\u0005�\\\n\u0013\u0004�\\+\u0013\u0003���\u0013���\u0011�\\#\u0000\\\n�\\\t\u0000/�\u0008\u0000<\u0000���\u0000���\u0000�\u0000�\u0000�\u00005\u0000E\u0000=\u0000���������\u0000�\u0000k\u0000A\u00009\u0000�\u0000�\u0000���\u0000���\u0000\u0007\u0000g\u0000\u0004\u00003\u0000\u0005\u0000\u0016).*?(?-i:\u0002hq\u0003h2c\u0006spdy/3\u0006spdy/2\u0006spdy/1\u0008http/1\\.0\u0008http/0\\.9)"
@@ -115631,8 +114955,7 @@ rules:
       to_client: true
   - name: "sid:2036695"
     description: "ET INFO Possible JARM Fingerprinting Client Hello via tls1_1_middle_out"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0016\u00003\u0000g����\u0000�\u00009\u0000k����\u0000�\u0000E\u0000�\u0000�\u0000�\u0000��\u0008�\\\t�\\#�����\\+�\\\n�\\$�����,�r�s̩\u0013\u0002\u0013\u0001�\u0014�\u0007�\u0012�\u0013�'�/�\u0014�\\(�0�`�a�v�w̨\u0013\u0005\u0013\u0004\u0013\u0003�\u0013�\u0011\u0000\\\n\u0000/\u0000<����\u0000�\u00005\u0000=����\u0000�\u0000A\u0000�\u0000�\u0000�\u0000\u0007\u0000\u0004\u0000\u0005).*?(?-i:\u0008http/0\\.9\u0008http/1\\.0\u0008http/1\\.1\u0006spdy/1\u0006spdy/2\u0006spdy/3\u0002h2\u0003h2c\u0002hq)"
@@ -115642,8 +114965,7 @@ rules:
       to_client: true
   - name: "sid:2036696"
     description: "ET INFO Possible JARM Fingerprinting Client Hello via tls1_3_forward"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0016\u00003\u0000g����\u0000�\u00009\u0000k����\u0000�\u0000E\u0000�\u0000�\u0000�\u0000��\u0008�\\\t�\\#�����\\+�\\\n�\\$�����,�r�s̩\u0013\u0002\u0013\u0001�\u0014�\u0007�\u0012�\u0013�'�/�\u0014�\\(�0�`�a�v�w̨\u0013\u0005\u0013\u0004\u0013\u0003�\u0013�\u0011\u0000\\\n\u0000/\u0000<����\u0000�\u00005\u0000=����\u0000�\u0000A\u0000�\u0000�\u0000�\u0000\u0007\u0000\u0004\u0000\u0005).*?(?-i:\u0002hq\u0003h2c\u0002h2\u0006spdy/3\u0006spdy/2\u0006spdy/1\u0008http/1\\.1\u0008http/1\\.0\u0008http/0\\.9).*?(?-i:\u0003\u0004\u0003\u0003\u0003\u0002\u0003\u0001)"
@@ -115653,8 +114975,7 @@ rules:
       to_client: true
   - name: "sid:2036697"
     description: "ET INFO Possible JARM Fingerprinting Client Hello via tls1_3_reverse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0016\u0003\u0001).*?(?-i:\u0000\u0005\u0000\u0004\u0000\u0007\u0000�\u0000�\u0000�\u0000A\u0000�����\u0000=\u00005\u0000�����\u0000<\u0000/\u0000\\\n�\u0011�\u0013\u0013\u0003\u0013\u0004\u0013\u0005̨�w�v�a�`�0�\\(�\u0014�/�'�\u0013�\u0012�\u0007�\u0014\u0013\u0001\u0013\u0002̩�s�r�,�����\\$�\\\n�\\+�����\\#�\\\t�\u0008\u0000�\u0000�\u0000�\u0000�\u0000E\u0000�����\u0000k\u00009\u0000�����\u0000g\u00003\u0000\u0016).*?(?-i:\u0008http/0\\.9\u0008http/1\\.0\u0008http/1\\.1\u0006spdy/1\u0006spdy/2\u0006spdy/3\u0002h2\u0003h2c\u0002hq).*?(?-i:\u0003\u0001\u0003\u0002\u0003\u0003\u0003\u0004)"
@@ -115664,8 +114985,7 @@ rules:
       to_client: true
   - name: "sid:2036699"
     description: "ET INFO Possible JARM Fingerprinting Client Hello via tls1_3_invalid"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0016\u0003\u0001).*?(?-i:\u0000\u0016\u00003\u0000g����\u0000�\u00009\u0000k����\u0000�\u0000E\u0000�\u0000�\u0000�\u0000��\u0008�\\\t�\\#�����\\+�\\\n�\\$�����,�r�s̩�\u0014�\u0007�\u0012�\u0013�'�/�\u0014�\\(�0�`�a�v�w̨�\u0013�\u0011\u0000\\\n\u0000/\u0000<����\u0000�\u00005\u0000=����\u0000�\u0000A\u0000�\u0000�\u0000�\u0000\u0007\u0000\u0004\u0000\u0005).*?(?-i:\u0008http/0\\.9\u0008http/1\\.0\u0008http/1\\.1\u0006spdy/1\u0006spdy/2\u0006spdy/3\u0002h2\u0003h2c\u0002hq).*?(?-i:\u0003\u0001\u0003\u0002\u0003\u0003\u0003\u0004)"
@@ -115675,8 +114995,7 @@ rules:
       to_client: true
   - name: "sid:2036700"
     description: "ET INFO Possible JARM Fingerprinting Client Hello via tls1_3_middle_out"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0016\u0003\u0001).*?(?-i:�\u0012�\u0013�\u0007�'�\u0014�/\u0013\u0001�\u0014\u0013\u0002�\\(̩�0�s�`�r�a�,�v���w��̨�\\$\u0013\u0005�\\\n\u0013\u0004�\\+\u0013\u0003���\u0013���\u0011�\\#\u0000\\\n�\\\t\u0000/�\u0008\u0000<\u0000���\u0000���\u0000�\u0000�\u0000�\u00005\u0000E\u0000=\u0000���������\u0000�\u0000k\u0000A\u00009\u0000�\u0000�\u0000���\u0000���\u0000\u0007\u0000g\u0000\u0004\u00003\u0000\u0005\u0000\u0016).*?(?-i:\u0002hq\u0003h2c\u0002h2\u0006spdy/3\u0006spdy/2\u0006spdy/1\u0008http/1\\.1\u0008http/1\\.0\u0008http/0\\.9).*?(?-i:\u0003\u0004\u0003\u0003\u0003\u0002\u0003\u0001)"
@@ -116230,8 +115549,7 @@ rules:
       to_server: true
   - name: "sid:2036835"
     description: "ET MALWARE Win32/Darkme Trojan Checkin M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -116375,8 +115693,7 @@ rules:
       to_server: true
   - name: "sid:2035939"
     description: "ET MALWARE Fodcha Bot CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -116657,8 +115974,7 @@ rules:
       to_server: true
   - name: "sid:2036933"
     description: "ET MALWARE njRAT v65.0 CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -118091,8 +117407,7 @@ rules:
       to_server: true
   - name: "sid:2037250"
     description: "ET MALWARE Win32/Remcos RAT Checkin 809"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -118103,8 +117418,7 @@ rules:
       to_server: true
   - name: "sid:2037251"
     description: "ET MALWARE Win32/Remcos RAT Checkin 810"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -118426,8 +117740,7 @@ rules:
       to_server: true
   - name: "sid:2016101"
     description: "ET MALWARE DNS Reply Sinkhole - Microsoft - 131.253.18.11-12"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0001\u0000\u0001).{4,5}(?-i:\u0000\u0004��\u0012)"
@@ -118453,40 +117766,35 @@ rules:
         no_case: false
   - name: "sid:2016102"
     description: "ET MALWARE DNS Reply Sinkhole - Microsoft - 199.2.137.0/24"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0001\u0000\u0001).{4,5}(?-i:\u0000\u0004�\u0002�)"
       case_insensitive: false
   - name: "sid:2016413"
     description: "ET DNS Reply Sinkhole - sinkhole.cert.pl 148.81.111.111"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0001\u0000\u0001).{4,6}(?-i:\u0000\u0004�Qoo)"
       case_insensitive: false
   - name: "sid:2016418"
     description: "ET DNS Reply Sinkhole - Dr. Web"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0001\u0000\u0001).{4,6}(?-i:\u0000\u0004\\[��j)"
       case_insensitive: false
   - name: "sid:2016419"
     description: "ET DNS Reply Sinkhole - Zinkhole.org"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0001\u0000\u0001).{4,6}(?-i:\u0000\u0004�\u001f>L)"
       case_insensitive: false
   - name: "sid:2016422"
     description: "ET DNS Reply Sinkhole - Georgia Tech (1)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0001\u0000\u0001).{4,6}(?-i:\u0000\u0004�=�\u0006)"
@@ -118500,16 +117808,14 @@ rules:
       case_insensitive: false
   - name: "sid:2016591"
     description: "ET DNS Reply Sinkhole - 106.187.96.49 blacklistthisdomain.com"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0001\u0000\u0001).{4,6}(?-i:\u0000\u0004j�`1)"
       case_insensitive: false
   - name: "sid:2018455"
     description: "ET MALWARE DNS Reply Sinkhole - Anubis - 195.22.26.192/26"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0001\u0000\u0001).{4,5}(?-i:\u0000\u0004�\u0016\u001a)"
@@ -118526,16 +117832,14 @@ rules:
         no_case: false
   - name: "sid:2018642"
     description: "ET MALWARE DNS Reply Sinkhole Microsoft NO-IP Domain"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0001\u0000\u0001).{4,5}(?-i:\u0000\u0004�_c)"
       case_insensitive: false
   - name: "sid:2019508"
     description: "ET MALWARE DNS Reply Sinkhole - IP - 161.69.13.44"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0001\u0000\u0001).{4,6}(?-i:\u0000\u0004�E\\\r,)"
@@ -118595,8 +117899,7 @@ rules:
       case_insensitive: false
   - name: "sid:2036735"
     description: "ET MALWARE Ave Maria/Warzone RAT Encrypted CnC Checkin (Inbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -118707,8 +118010,7 @@ rules:
       to_server: true
   - name: "sid:2037801"
     description: "ET MALWARE Ave Maria/Warzone RAT Encrypted CnC Checkin (Inbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -118721,8 +118023,7 @@ rules:
       to_client: true
   - name: "sid:2029606"
     description: "ET MALWARE MSIL/Firebird RAT CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -118773,8 +118074,7 @@ rules:
       case_insensitive: false
   - name: "sid:2037811"
     description: "ET MALWARE Downloaded .PNG With Embedded File (.sh)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:image/png).*?(?-i:�PNG\\\r\\\n\u001a\\\n).{0,}(?-i:\u0000\u0000\u0000\u0000IEND�B`�\\#!/bin/sh)"
@@ -118897,8 +118197,7 @@ rules:
       to_server: true
   - name: "sid:2037841"
     description: "ET MALWARE W32.DarkVNC Variant Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119320,8 +118619,7 @@ rules:
       case_insensitive: false
   - name: "sid:2037961"
     description: "ET MALWARE ELF/RapperBot CnC Checkin M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119332,8 +118630,7 @@ rules:
       to_server: true
   - name: "sid:2037962"
     description: "ET MALWARE ELF/RapperBot CnC Checkin M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119365,8 +118662,7 @@ rules:
         flag: "ET.deimosc2.ja3"
   - name: "sid:2038474"
     description: "ET HUNTING HTTP GET Request XOR e4"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119437,8 +118733,7 @@ rules:
       to_server: true
   - name: "sid:2038347"
     description: "ET HUNTING HTTP POST Request XOR Key 81"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119515,8 +118810,7 @@ rules:
       to_server: true
   - name: "sid:2038370"
     description: "ET HUNTING HTTP POST Request XOR Key 98"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119527,8 +118821,7 @@ rules:
       to_server: true
   - name: "sid:2038393"
     description: "ET HUNTING HTTP POST Request XOR Key af"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119539,8 +118832,7 @@ rules:
       to_server: true
   - name: "sid:2038447"
     description: "ET HUNTING HTTP POST Request XOR Key e5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119551,8 +118843,7 @@ rules:
       to_server: true
   - name: "sid:2038454"
     description: "ET HUNTING HTTP POST Request XOR Key ec"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119574,8 +118865,7 @@ rules:
       to_server: true
   - name: "sid:2038410"
     description: "ET HUNTING HTTP POST Request XOR Key c0"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119586,8 +118876,7 @@ rules:
       to_server: true
   - name: "sid:2038445"
     description: "ET HUNTING HTTP POST Request XOR Key e3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119620,8 +118909,7 @@ rules:
       to_server: true
   - name: "sid:2038373"
     description: "ET HUNTING HTTP POST Request XOR Key 9b"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119632,8 +118920,7 @@ rules:
       to_server: true
   - name: "sid:2038385"
     description: "ET HUNTING HTTP POST Request XOR Key a7"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119644,8 +118931,7 @@ rules:
       to_server: true
   - name: "sid:2038460"
     description: "ET HUNTING HTTP POST Request XOR Key f2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119678,8 +118964,7 @@ rules:
       to_server: true
   - name: "sid:2038346"
     description: "ET HUNTING HTTP POST Request XOR Key 80"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119701,8 +118986,7 @@ rules:
       to_server: true
   - name: "sid:2038366"
     description: "ET HUNTING HTTP POST Request XOR Key 94"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119713,8 +118997,7 @@ rules:
       to_server: true
   - name: "sid:2038412"
     description: "ET HUNTING HTTP POST Request XOR Key c2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119725,8 +119008,7 @@ rules:
       to_server: true
   - name: "sid:2038417"
     description: "ET HUNTING HTTP POST Request XOR Key c7"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119737,8 +119019,7 @@ rules:
       to_server: true
   - name: "sid:2038427"
     description: "ET HUNTING HTTP POST Request XOR Key d1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119749,8 +119030,7 @@ rules:
       to_server: true
   - name: "sid:2038367"
     description: "ET HUNTING HTTP POST Request XOR Key 95"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119772,8 +119052,7 @@ rules:
       to_server: true
   - name: "sid:2038350"
     description: "ET HUNTING HTTP POST Request XOR Key 84"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119784,8 +119063,7 @@ rules:
       to_server: true
   - name: "sid:2038361"
     description: "ET HUNTING HTTP POST Request XOR Key 8f"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119807,8 +119085,7 @@ rules:
       to_server: true
   - name: "sid:2038400"
     description: "ET HUNTING HTTP POST Request XOR Key b6"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119852,8 +119129,7 @@ rules:
       to_server: true
   - name: "sid:2038351"
     description: "ET HUNTING HTTP POST Request XOR Key 85"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119864,8 +119140,7 @@ rules:
       to_server: true
   - name: "sid:2038435"
     description: "ET HUNTING HTTP POST Request XOR Key d9"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119876,8 +119151,7 @@ rules:
       to_server: true
   - name: "sid:2038358"
     description: "ET HUNTING HTTP POST Request XOR Key 8c"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119888,8 +119162,7 @@ rules:
       to_server: true
   - name: "sid:2038424"
     description: "ET HUNTING HTTP POST Request XOR Key ce"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119911,8 +119184,7 @@ rules:
       to_server: true
   - name: "sid:2038463"
     description: "ET HUNTING HTTP POST Request XOR Key f5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119934,8 +119206,7 @@ rules:
       to_server: true
   - name: "sid:2038405"
     description: "ET HUNTING HTTP POST Request XOR Key bb"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119957,8 +119228,7 @@ rules:
       to_server: true
   - name: "sid:2038426"
     description: "ET HUNTING HTTP POST Request XOR Key d0"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -119980,8 +119250,7 @@ rules:
       to_server: true
   - name: "sid:2038444"
     description: "ET HUNTING HTTP POST Request XOR Key e2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120058,8 +119327,7 @@ rules:
       to_server: true
   - name: "sid:2038376"
     description: "ET HUNTING HTTP POST Request XOR Key 9e"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120070,8 +119338,7 @@ rules:
       to_server: true
   - name: "sid:2038455"
     description: "ET HUNTING HTTP POST Request XOR Key ed"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120104,8 +119371,7 @@ rules:
       to_server: true
   - name: "sid:2038456"
     description: "ET HUNTING HTTP POST Request XOR Key ee"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120116,8 +119382,7 @@ rules:
       to_server: true
   - name: "sid:2038438"
     description: "ET HUNTING HTTP POST Request XOR Key dc"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120139,8 +119404,7 @@ rules:
       to_server: true
   - name: "sid:2038368"
     description: "ET HUNTING HTTP POST Request XOR Key 96"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120162,8 +119426,7 @@ rules:
       to_server: true
   - name: "sid:2038356"
     description: "ET HUNTING HTTP POST Request XOR Key 8a"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120174,8 +119437,7 @@ rules:
       to_server: true
   - name: "sid:2038434"
     description: "ET HUNTING HTTP POST Request XOR Key d8"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120186,8 +119448,7 @@ rules:
       to_server: true
   - name: "sid:2038411"
     description: "ET HUNTING HTTP POST Request XOR Key c1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120264,8 +119525,7 @@ rules:
       to_server: true
   - name: "sid:2038451"
     description: "ET HUNTING HTTP POST Request XOR Key e9"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120276,8 +119536,7 @@ rules:
       to_server: true
   - name: "sid:2038425"
     description: "ET HUNTING HTTP POST Request XOR Key cf"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120288,8 +119547,7 @@ rules:
       to_server: true
   - name: "sid:2038390"
     description: "ET HUNTING HTTP POST Request XOR Key ac"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120300,8 +119558,7 @@ rules:
       to_server: true
   - name: "sid:2038437"
     description: "ET HUNTING HTTP POST Request XOR Key db"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120312,8 +119569,7 @@ rules:
       to_server: true
   - name: "sid:2038401"
     description: "ET HUNTING HTTP POST Request XOR Key b7"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120324,8 +119580,7 @@ rules:
       to_server: true
   - name: "sid:2038379"
     description: "ET HUNTING HTTP POST Request XOR Key a1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120380,8 +119635,7 @@ rules:
       to_server: true
   - name: "sid:2038468"
     description: "ET HUNTING HTTP POST Request XOR Key fa"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120392,8 +119646,7 @@ rules:
       to_server: true
   - name: "sid:2038469"
     description: "ET HUNTING HTTP POST Request XOR Key fb"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120415,8 +119668,7 @@ rules:
       to_server: true
   - name: "sid:2038430"
     description: "ET HUNTING HTTP POST Request XOR Key d4"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120449,8 +119701,7 @@ rules:
       to_server: true
   - name: "sid:2038377"
     description: "ET HUNTING HTTP POST Request XOR Key 9f"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120461,8 +119712,7 @@ rules:
       to_server: true
   - name: "sid:2038382"
     description: "ET HUNTING HTTP POST Request XOR Key a4"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120484,8 +119734,7 @@ rules:
       to_server: true
   - name: "sid:2038359"
     description: "ET HUNTING HTTP POST Request XOR Key 8d"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120496,8 +119745,7 @@ rules:
       to_server: true
   - name: "sid:2038399"
     description: "ET HUNTING HTTP POST Request XOR Key b5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120541,8 +119789,7 @@ rules:
       to_server: true
   - name: "sid:2038433"
     description: "ET HUNTING HTTP POST Request XOR Key d7"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120575,8 +119822,7 @@ rules:
       to_server: true
   - name: "sid:2038389"
     description: "ET HUNTING HTTP POST Request XOR Key ab"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120609,8 +119855,7 @@ rules:
       to_server: true
   - name: "sid:2038402"
     description: "ET HUNTING HTTP POST Request XOR Key b8"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120632,8 +119877,7 @@ rules:
       to_server: true
   - name: "sid:2038392"
     description: "ET HUNTING HTTP POST Request XOR Key ae"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120666,8 +119910,7 @@ rules:
       to_server: true
   - name: "sid:2038461"
     description: "ET HUNTING HTTP POST Request XOR Key f3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120700,8 +119943,7 @@ rules:
       to_server: true
   - name: "sid:2038375"
     description: "ET HUNTING HTTP POST Request XOR Key 9d"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120734,8 +119976,7 @@ rules:
       to_server: true
   - name: "sid:2038464"
     description: "ET HUNTING HTTP POST Request XOR Key f6"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120746,8 +119987,7 @@ rules:
       to_server: true
   - name: "sid:2038354"
     description: "ET HUNTING HTTP POST Request XOR Key 88"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120758,8 +119998,7 @@ rules:
       to_server: true
   - name: "sid:2038409"
     description: "ET HUNTING HTTP POST Request XOR Key bf"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120825,8 +120064,7 @@ rules:
       to_server: true
   - name: "sid:2038369"
     description: "ET HUNTING HTTP POST Request XOR Key 97"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120848,8 +120086,7 @@ rules:
       to_server: true
   - name: "sid:2038413"
     description: "ET HUNTING HTTP POST Request XOR Key c3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120860,8 +120097,7 @@ rules:
       to_server: true
   - name: "sid:2038457"
     description: "ET HUNTING HTTP POST Request XOR Key ef"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120872,8 +120108,7 @@ rules:
       to_server: true
   - name: "sid:2038404"
     description: "ET HUNTING HTTP POST Request XOR Key ba"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120884,8 +120119,7 @@ rules:
       to_server: true
   - name: "sid:2038458"
     description: "ET HUNTING HTTP POST Request XOR Key f0"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120896,8 +120130,7 @@ rules:
       to_server: true
   - name: "sid:2038396"
     description: "ET HUNTING HTTP POST Request XOR Key b2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120908,8 +120141,7 @@ rules:
       to_server: true
   - name: "sid:2038450"
     description: "ET HUNTING HTTP POST Request XOR Key e8"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120931,8 +120163,7 @@ rules:
       to_server: true
   - name: "sid:2038360"
     description: "ET HUNTING HTTP POST Request XOR Key 8e"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120943,8 +120174,7 @@ rules:
       to_server: true
   - name: "sid:2038349"
     description: "ET HUNTING HTTP POST Request XOR Key 83"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120955,8 +120185,7 @@ rules:
       to_server: true
   - name: "sid:2038397"
     description: "ET HUNTING HTTP POST Request XOR Key b3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -120967,8 +120196,7 @@ rules:
       to_server: true
   - name: "sid:2038384"
     description: "ET HUNTING HTTP POST Request XOR Key a6"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121089,8 +120317,7 @@ rules:
       to_server: true
   - name: "sid:2038374"
     description: "ET HUNTING HTTP POST Request XOR Key 9c"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121101,8 +120328,7 @@ rules:
       to_server: true
   - name: "sid:2038473"
     description: "ET HUNTING HTTP POST Request XOR Key ff"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121113,8 +120339,7 @@ rules:
       to_server: true
   - name: "sid:2038380"
     description: "ET HUNTING HTTP POST Request XOR Key a2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121136,8 +120361,7 @@ rules:
       to_server: true
   - name: "sid:2038408"
     description: "ET HUNTING HTTP POST Request XOR Key be"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121148,8 +120372,7 @@ rules:
       to_server: true
   - name: "sid:2038414"
     description: "ET HUNTING HTTP POST Request XOR Key c4"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121171,8 +120394,7 @@ rules:
       to_server: true
   - name: "sid:2038459"
     description: "ET HUNTING HTTP POST Request XOR Key f1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121183,8 +120405,7 @@ rules:
       to_server: true
   - name: "sid:2038448"
     description: "ET HUNTING HTTP POST Request XOR Key e6"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121206,8 +120427,7 @@ rules:
       to_server: true
   - name: "sid:2038406"
     description: "ET HUNTING HTTP POST Request XOR Key bc"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121218,8 +120438,7 @@ rules:
       to_server: true
   - name: "sid:2038472"
     description: "ET HUNTING HTTP POST Request XOR Key fe"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121241,8 +120460,7 @@ rules:
       to_server: true
   - name: "sid:2038419"
     description: "ET HUNTING HTTP POST Request XOR Key c9"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121264,8 +120482,7 @@ rules:
       to_server: true
   - name: "sid:2038423"
     description: "ET HUNTING HTTP POST Request XOR Key cd"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121276,8 +120493,7 @@ rules:
       to_server: true
   - name: "sid:2038403"
     description: "ET HUNTING HTTP POST Request XOR Key b9"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121288,8 +120504,7 @@ rules:
       to_server: true
   - name: "sid:2038471"
     description: "ET HUNTING HTTP POST Request XOR Key fd"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121300,8 +120515,7 @@ rules:
       to_server: true
   - name: "sid:2038387"
     description: "ET HUNTING HTTP POST Request XOR Key a9"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121312,8 +120526,7 @@ rules:
       to_server: true
   - name: "sid:2038449"
     description: "ET HUNTING HTTP POST Request XOR Key e7"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121357,8 +120570,7 @@ rules:
       to_server: true
   - name: "sid:2038365"
     description: "ET HUNTING HTTP POST Request XOR Key 93"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121380,8 +120592,7 @@ rules:
       to_server: true
   - name: "sid:2038422"
     description: "ET HUNTING HTTP POST Request XOR Key cc"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121414,8 +120625,7 @@ rules:
       to_server: true
   - name: "sid:2038443"
     description: "ET HUNTING HTTP POST Request XOR Key e1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121481,8 +120691,7 @@ rules:
       to_server: true
   - name: "sid:2038421"
     description: "ET HUNTING HTTP POST Request XOR Key cb"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121493,8 +120702,7 @@ rules:
       to_server: true
   - name: "sid:2038348"
     description: "ET HUNTING HTTP POST Request XOR Key 82"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121505,8 +120713,7 @@ rules:
       to_server: true
   - name: "sid:2038446"
     description: "ET HUNTING HTTP POST Request XOR Key e4"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121528,8 +120735,7 @@ rules:
       to_server: true
   - name: "sid:2038439"
     description: "ET HUNTING HTTP POST Request XOR Key dd"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121540,8 +120746,7 @@ rules:
       to_server: true
   - name: "sid:2038353"
     description: "ET HUNTING HTTP POST Request XOR Key 87"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121552,8 +120757,7 @@ rules:
       to_server: true
   - name: "sid:2038441"
     description: "ET HUNTING HTTP POST Request XOR Key df"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121564,8 +120768,7 @@ rules:
       to_server: true
   - name: "sid:2038372"
     description: "ET HUNTING HTTP POST Request XOR Key 9a"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121576,8 +120779,7 @@ rules:
       to_server: true
   - name: "sid:2038418"
     description: "ET HUNTING HTTP POST Request XOR Key c8"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121588,8 +120790,7 @@ rules:
       to_server: true
   - name: "sid:2038466"
     description: "ET HUNTING HTTP POST Request XOR Key f8"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121600,8 +120801,7 @@ rules:
       to_server: true
   - name: "sid:2038362"
     description: "ET HUNTING HTTP POST Request XOR Key 90"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121623,8 +120823,7 @@ rules:
       to_server: true
   - name: "sid:2038429"
     description: "ET HUNTING HTTP POST Request XOR Key d3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121657,8 +120856,7 @@ rules:
       to_server: true
   - name: "sid:2038386"
     description: "ET HUNTING HTTP POST Request XOR Key a8"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121669,8 +120867,7 @@ rules:
       to_server: true
   - name: "sid:2038452"
     description: "ET HUNTING HTTP POST Request XOR Key ea"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121703,8 +120900,7 @@ rules:
       to_server: true
   - name: "sid:2038388"
     description: "ET HUNTING HTTP POST Request XOR Key aa"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121726,8 +120922,7 @@ rules:
       to_server: true
   - name: "sid:2038467"
     description: "ET HUNTING HTTP POST Request XOR Key f9"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121771,8 +120966,7 @@ rules:
       to_server: true
   - name: "sid:2038428"
     description: "ET HUNTING HTTP POST Request XOR Key d2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121783,8 +120977,7 @@ rules:
       to_server: true
   - name: "sid:2038355"
     description: "ET HUNTING HTTP POST Request XOR Key 89"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121839,8 +121032,7 @@ rules:
       to_server: true
   - name: "sid:2038436"
     description: "ET HUNTING HTTP POST Request XOR Key da"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121862,8 +121054,7 @@ rules:
       to_server: true
   - name: "sid:2038416"
     description: "ET HUNTING HTTP POST Request XOR Key c6"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121874,8 +121065,7 @@ rules:
       to_server: true
   - name: "sid:2038432"
     description: "ET HUNTING HTTP POST Request XOR Key d6"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121886,8 +121076,7 @@ rules:
       to_server: true
   - name: "sid:2038371"
     description: "ET HUNTING HTTP POST Request XOR Key 99"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121898,8 +121087,7 @@ rules:
       to_server: true
   - name: "sid:2038363"
     description: "ET HUNTING HTTP POST Request XOR Key 91"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121910,8 +121098,7 @@ rules:
       to_server: true
   - name: "sid:2038407"
     description: "ET HUNTING HTTP POST Request XOR Key bd"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121922,8 +121109,7 @@ rules:
       to_server: true
   - name: "sid:2038394"
     description: "ET HUNTING HTTP POST Request XOR Key b0"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121934,8 +121120,7 @@ rules:
       to_server: true
   - name: "sid:2038415"
     description: "ET HUNTING HTTP POST Request XOR Key c5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -121968,8 +121153,7 @@ rules:
       to_server: true
   - name: "sid:2038431"
     description: "ET HUNTING HTTP POST Request XOR Key d5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122002,8 +121186,7 @@ rules:
       to_server: true
   - name: "sid:2038364"
     description: "ET HUNTING HTTP POST Request XOR Key 92"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122014,8 +121197,7 @@ rules:
       to_server: true
   - name: "sid:2038470"
     description: "ET HUNTING HTTP POST Request XOR Key fc"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122048,8 +121230,7 @@ rules:
       to_server: true
   - name: "sid:2038391"
     description: "ET HUNTING HTTP POST Request XOR Key ad"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122060,8 +121241,7 @@ rules:
       to_server: true
   - name: "sid:2038465"
     description: "ET HUNTING HTTP POST Request XOR Key f7"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122072,8 +121252,7 @@ rules:
       to_server: true
   - name: "sid:2038383"
     description: "ET HUNTING HTTP POST Request XOR Key a5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122095,8 +121274,7 @@ rules:
       to_server: true
   - name: "sid:2038442"
     description: "ET HUNTING HTTP POST Request XOR Key e0"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122118,8 +121296,7 @@ rules:
       to_server: true
   - name: "sid:2038357"
     description: "ET HUNTING HTTP POST Request XOR Key 8b"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122130,8 +121307,7 @@ rules:
       to_server: true
   - name: "sid:2038395"
     description: "ET HUNTING HTTP POST Request XOR Key b1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122153,8 +121329,7 @@ rules:
       to_server: true
   - name: "sid:2038381"
     description: "ET HUNTING HTTP POST Request XOR Key a3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122176,8 +121351,7 @@ rules:
       to_server: true
   - name: "sid:2038453"
     description: "ET HUNTING HTTP POST Request XOR Key eb"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122188,8 +121362,7 @@ rules:
       to_server: true
   - name: "sid:2038378"
     description: "ET HUNTING HTTP POST Request XOR Key a0"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122244,8 +121417,7 @@ rules:
       to_server: true
   - name: "sid:2038440"
     description: "ET HUNTING HTTP POST Request XOR Key de"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122267,8 +121439,7 @@ rules:
       to_server: true
   - name: "sid:2038352"
     description: "ET HUNTING HTTP POST Request XOR Key 86"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122279,8 +121450,7 @@ rules:
       to_server: true
   - name: "sid:2038462"
     description: "ET HUNTING HTTP POST Request XOR Key f4"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122302,8 +121472,7 @@ rules:
       to_server: true
   - name: "sid:2038398"
     description: "ET HUNTING HTTP POST Request XOR Key b4"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122325,8 +121494,7 @@ rules:
       to_server: true
   - name: "sid:2038420"
     description: "ET HUNTING HTTP POST Request XOR Key ca"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122337,8 +121505,7 @@ rules:
       to_server: true
   - name: "sid:2038206"
     description: "ET HUNTING HTTP GET Request XOR Key f3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122349,8 +121516,7 @@ rules:
       to_server: true
   - name: "sid:2038203"
     description: "ET HUNTING HTTP GET Request XOR Key f0"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122372,8 +121538,7 @@ rules:
       to_server: true
   - name: "sid:2038111"
     description: "ET HUNTING HTTP GET Request XOR Key 93"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122395,8 +121560,7 @@ rules:
       to_server: true
   - name: "sid:2038144"
     description: "ET HUNTING HTTP GET Request XOR Key b4"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122418,8 +121582,7 @@ rules:
       to_server: true
   - name: "sid:2038114"
     description: "ET HUNTING HTTP GET Request XOR Key 96"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122430,8 +121593,7 @@ rules:
       to_server: true
   - name: "sid:2038094"
     description: "ET HUNTING HTTP GET Request XOR Key 82"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122464,8 +121626,7 @@ rules:
       to_server: true
   - name: "sid:2038175"
     description: "ET HUNTING HTTP GET Request XOR Key d3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122476,8 +121637,7 @@ rules:
       to_server: true
   - name: "sid:2038152"
     description: "ET HUNTING HTTP GET Request XOR Key bc"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122488,8 +121648,7 @@ rules:
       to_server: true
   - name: "sid:2038115"
     description: "ET HUNTING HTTP GET Request XOR Key 97"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122522,8 +121681,7 @@ rules:
       to_server: true
   - name: "sid:2038168"
     description: "ET HUNTING HTTP GET Request XOR Key cc"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122545,8 +121703,7 @@ rules:
       to_server: true
   - name: "sid:2038187"
     description: "ET HUNTING HTTP GET Request XOR Key df"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122557,8 +121714,7 @@ rules:
       to_server: true
   - name: "sid:2038099"
     description: "ET HUNTING HTTP GET Request XOR Key 87"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122569,8 +121725,7 @@ rules:
       to_server: true
   - name: "sid:2038171"
     description: "ET HUNTING HTTP GET Request XOR Key cf"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122581,8 +121736,7 @@ rules:
       to_server: true
   - name: "sid:2038143"
     description: "ET HUNTING HTTP GET Request XOR Key b3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122593,8 +121747,7 @@ rules:
       to_server: true
   - name: "sid:2038126"
     description: "ET HUNTING HTTP GET Request XOR Key a2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122605,8 +121758,7 @@ rules:
       to_server: true
   - name: "sid:2038122"
     description: "ET HUNTING HTTP GET Request XOR Key 9e"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122639,8 +121791,7 @@ rules:
       to_server: true
   - name: "sid:2038092"
     description: "ET HUNTING HTTP GET Request XOR Key 80"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122662,8 +121813,7 @@ rules:
       to_server: true
   - name: "sid:2038146"
     description: "ET HUNTING HTTP GET Request XOR Key b6"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122674,8 +121824,7 @@ rules:
       to_server: true
   - name: "sid:2038201"
     description: "ET HUNTING HTTP GET Request XOR Key ee"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122686,8 +121835,7 @@ rules:
       to_server: true
   - name: "sid:2038176"
     description: "ET HUNTING HTTP GET Request XOR Key d4"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122709,8 +121857,7 @@ rules:
       to_server: true
   - name: "sid:2038138"
     description: "ET HUNTING HTTP GET Request XOR Key ae"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122743,8 +121890,7 @@ rules:
       to_server: true
   - name: "sid:2038163"
     description: "ET HUNTING HTTP GET Request XOR Key c7"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122755,8 +121901,7 @@ rules:
       to_server: true
   - name: "sid:2038165"
     description: "ET HUNTING HTTP GET Request XOR Key c9"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122767,8 +121912,7 @@ rules:
       to_server: true
   - name: "sid:2038102"
     description: "ET HUNTING HTTP GET Request XOR Key 8a"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122790,8 +121934,7 @@ rules:
       to_server: true
   - name: "sid:2038196"
     description: "ET HUNTING HTTP GET Request XOR Key e9"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122802,8 +121945,7 @@ rules:
       to_server: true
   - name: "sid:2038164"
     description: "ET HUNTING HTTP GET Request XOR Key c8"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122847,8 +121989,7 @@ rules:
       to_server: true
   - name: "sid:2038182"
     description: "ET HUNTING HTTP GET Request XOR Key da"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122870,8 +122011,7 @@ rules:
       to_server: true
   - name: "sid:2038178"
     description: "ET HUNTING HTTP GET Request XOR Key d6"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122882,8 +122022,7 @@ rules:
       to_server: true
   - name: "sid:2038197"
     description: "ET HUNTING HTTP GET Request XOR Key ea"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122905,8 +122044,7 @@ rules:
       to_server: true
   - name: "sid:2038093"
     description: "ET HUNTING HTTP GET Request XOR Key 81"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122917,8 +122055,7 @@ rules:
       to_server: true
   - name: "sid:2038149"
     description: "ET HUNTING HTTP GET Request XOR Key b9"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122940,8 +122077,7 @@ rules:
       to_server: true
   - name: "sid:2038137"
     description: "ET HUNTING HTTP GET Request XOR Key ad"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122963,8 +122099,7 @@ rules:
       to_server: true
   - name: "sid:2038194"
     description: "ET HUNTING HTTP GET Request XOR Key e7"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122986,8 +122121,7 @@ rules:
       to_server: true
   - name: "sid:2038209"
     description: "ET HUNTING HTTP GET Request XOR Key f6"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -122998,8 +122132,7 @@ rules:
       to_server: true
   - name: "sid:2038154"
     description: "ET HUNTING HTTP GET Request XOR Key be"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123010,8 +122143,7 @@ rules:
       to_server: true
   - name: "sid:2038210"
     description: "ET HUNTING HTTP GET Request XOR Key f7"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123022,8 +122154,7 @@ rules:
       to_server: true
   - name: "sid:2038128"
     description: "ET HUNTING HTTP GET Request XOR Key a4"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123056,8 +122187,7 @@ rules:
       to_server: true
   - name: "sid:2038148"
     description: "ET HUNTING HTTP GET Request XOR Key b8"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123112,8 +122242,7 @@ rules:
       to_server: true
   - name: "sid:2038177"
     description: "ET HUNTING HTTP GET Request XOR Key d5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123146,8 +122275,7 @@ rules:
       to_server: true
   - name: "sid:2038153"
     description: "ET HUNTING HTTP GET Request XOR Key bd"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123158,8 +122286,7 @@ rules:
       to_server: true
   - name: "sid:2038214"
     description: "ET HUNTING HTTP GET Request XOR Key fb"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123170,8 +122297,7 @@ rules:
       to_server: true
   - name: "sid:2038207"
     description: "ET HUNTING HTTP GET Request XOR Key f4"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123237,8 +122363,7 @@ rules:
       to_server: true
   - name: "sid:2038110"
     description: "ET HUNTING HTTP GET Request XOR Key 92"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123282,8 +122407,7 @@ rules:
       to_server: true
   - name: "sid:2038188"
     description: "ET HUNTING HTTP GET Request XOR Key e0"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123294,8 +122418,7 @@ rules:
       to_server: true
   - name: "sid:2038202"
     description: "ET HUNTING HTTP GET Request XOR Key ef"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123306,8 +122429,7 @@ rules:
       to_server: true
   - name: "sid:2038199"
     description: "ET HUNTING HTTP GET Request XOR Key ec"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123340,8 +122462,7 @@ rules:
       to_server: true
   - name: "sid:2038158"
     description: "ET HUNTING HTTP GET Request XOR Key c2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123352,8 +122473,7 @@ rules:
       to_server: true
   - name: "sid:2038212"
     description: "ET HUNTING HTTP GET Request XOR Key f9"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123364,8 +122484,7 @@ rules:
       to_server: true
   - name: "sid:2038145"
     description: "ET HUNTING HTTP GET Request XOR Key b5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123387,8 +122506,7 @@ rules:
       to_server: true
   - name: "sid:2038218"
     description: "ET HUNTING HTTP GET Request XOR Key ff"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123399,8 +122517,7 @@ rules:
       to_server: true
   - name: "sid:2038098"
     description: "ET HUNTING HTTP GET Request XOR Key 86"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123411,8 +122528,7 @@ rules:
       to_server: true
   - name: "sid:2038192"
     description: "ET HUNTING HTTP GET Request XOR Key e5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123478,8 +122594,7 @@ rules:
       to_server: true
   - name: "sid:2038172"
     description: "ET HUNTING HTTP GET Request XOR Key d0"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123490,8 +122605,7 @@ rules:
       to_server: true
   - name: "sid:2038213"
     description: "ET HUNTING HTTP GET Request XOR Key fa"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123524,8 +122638,7 @@ rules:
       to_server: true
   - name: "sid:2038101"
     description: "ET HUNTING HTTP GET Request XOR Key 89"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123558,8 +122671,7 @@ rules:
       to_server: true
   - name: "sid:2038097"
     description: "ET HUNTING HTTP GET Request XOR Key 85"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123614,8 +122726,7 @@ rules:
       to_server: true
   - name: "sid:2038123"
     description: "ET HUNTING HTTP GET Request XOR Key 9f"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123626,8 +122737,7 @@ rules:
       to_server: true
   - name: "sid:2038179"
     description: "ET HUNTING HTTP GET Request XOR Key d7"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123638,8 +122748,7 @@ rules:
       to_server: true
   - name: "sid:2038185"
     description: "ET HUNTING HTTP GET Request XOR Key dd"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123661,8 +122770,7 @@ rules:
       to_server: true
   - name: "sid:2038174"
     description: "ET HUNTING HTTP GET Request XOR Key d2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123695,8 +122803,7 @@ rules:
       to_server: true
   - name: "sid:2038190"
     description: "ET HUNTING HTTP GET Request XOR Key e2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123718,8 +122825,7 @@ rules:
       to_server: true
   - name: "sid:2038096"
     description: "ET HUNTING HTTP GET Request XOR Key 84"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123741,8 +122847,7 @@ rules:
       to_server: true
   - name: "sid:2038215"
     description: "ET HUNTING HTTP GET Request XOR Key fc"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123797,8 +122902,7 @@ rules:
       to_server: true
   - name: "sid:2038157"
     description: "ET HUNTING HTTP GET Request XOR Key c1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123809,8 +122913,7 @@ rules:
       to_server: true
   - name: "sid:2038131"
     description: "ET HUNTING HTTP GET Request XOR Key a7"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123821,8 +122924,7 @@ rules:
       to_server: true
   - name: "sid:2038183"
     description: "ET HUNTING HTTP GET Request XOR Key db"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123888,8 +122990,7 @@ rules:
       to_server: true
   - name: "sid:2038103"
     description: "ET HUNTING HTTP GET Request XOR Key 8b"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123911,8 +123012,7 @@ rules:
       to_server: true
   - name: "sid:2038169"
     description: "ET HUNTING HTTP GET Request XOR Key cd"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123934,8 +123034,7 @@ rules:
       to_server: true
   - name: "sid:2038100"
     description: "ET HUNTING HTTP GET Request XOR Key 88"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123946,8 +123045,7 @@ rules:
       to_server: true
   - name: "sid:2038095"
     description: "ET HUNTING HTTP GET Request XOR Key 83"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123958,8 +123056,7 @@ rules:
       to_server: true
   - name: "sid:2038133"
     description: "ET HUNTING HTTP GET Request XOR Key a9"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123970,8 +123067,7 @@ rules:
       to_server: true
   - name: "sid:2038195"
     description: "ET HUNTING HTTP GET Request XOR Key e8"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -123982,8 +123078,7 @@ rules:
       to_server: true
   - name: "sid:2038186"
     description: "ET HUNTING HTTP GET Request XOR Key de"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124016,8 +123111,7 @@ rules:
       to_server: true
   - name: "sid:2038147"
     description: "ET HUNTING HTTP GET Request XOR Key b7"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124028,8 +123122,7 @@ rules:
       to_server: true
   - name: "sid:2038180"
     description: "ET HUNTING HTTP GET Request XOR Key d8"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124051,8 +123144,7 @@ rules:
       to_server: true
   - name: "sid:2038159"
     description: "ET HUNTING HTTP GET Request XOR Key c3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124074,8 +123166,7 @@ rules:
       to_server: true
   - name: "sid:2038139"
     description: "ET HUNTING HTTP GET Request XOR Key af"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124086,8 +123177,7 @@ rules:
       to_server: true
   - name: "sid:2038107"
     description: "ET HUNTING HTTP GET Request XOR Key 8f"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124164,8 +123254,7 @@ rules:
       to_server: true
   - name: "sid:2038124"
     description: "ET HUNTING HTTP GET Request XOR Key a0"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124187,8 +123276,7 @@ rules:
       to_server: true
   - name: "sid:2038198"
     description: "ET HUNTING HTTP GET Request XOR Key eb"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124243,8 +123331,7 @@ rules:
       to_server: true
   - name: "sid:2038109"
     description: "ET HUNTING HTTP GET Request XOR Key 91"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124277,8 +123364,7 @@ rules:
       to_server: true
   - name: "sid:2038130"
     description: "ET HUNTING HTTP GET Request XOR Key a6"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124289,8 +123375,7 @@ rules:
       to_server: true
   - name: "sid:2038141"
     description: "ET HUNTING HTTP GET Request XOR Key b1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124312,8 +123397,7 @@ rules:
       to_server: true
   - name: "sid:2038161"
     description: "ET HUNTING HTTP GET Request XOR Key c5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124324,8 +123408,7 @@ rules:
       to_server: true
   - name: "sid:2038170"
     description: "ET HUNTING HTTP GET Request XOR Key ce"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124347,8 +123430,7 @@ rules:
       to_server: true
   - name: "sid:2038167"
     description: "ET HUNTING HTTP GET Request XOR Key cb"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124370,8 +123452,7 @@ rules:
       to_server: true
   - name: "sid:2038116"
     description: "ET HUNTING HTTP GET Request XOR Key 98"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124382,8 +123463,7 @@ rules:
       to_server: true
   - name: "sid:2038119"
     description: "ET HUNTING HTTP GET Request XOR Key 9b"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124394,8 +123474,7 @@ rules:
       to_server: true
   - name: "sid:2038108"
     description: "ET HUNTING HTTP GET Request XOR Key 90"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124417,8 +123496,7 @@ rules:
       to_server: true
   - name: "sid:2038162"
     description: "ET HUNTING HTTP GET Request XOR Key c6"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124440,8 +123518,7 @@ rules:
       to_server: true
   - name: "sid:2038156"
     description: "ET HUNTING HTTP GET Request XOR Key c0"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124452,8 +123529,7 @@ rules:
       to_server: true
   - name: "sid:2038136"
     description: "ET HUNTING HTTP GET Request XOR Key ac"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124464,8 +123540,7 @@ rules:
       to_server: true
   - name: "sid:2038127"
     description: "ET HUNTING HTTP GET Request XOR Key a3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124476,8 +123551,7 @@ rules:
       to_server: true
   - name: "sid:2038113"
     description: "ET HUNTING HTTP GET Request XOR Key 95"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124499,8 +123573,7 @@ rules:
       to_server: true
   - name: "sid:2038208"
     description: "ET HUNTING HTTP GET Request XOR Key f5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124511,8 +123584,7 @@ rules:
       to_server: true
   - name: "sid:2038173"
     description: "ET HUNTING HTTP GET Request XOR Key d1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124523,8 +123595,7 @@ rules:
       to_server: true
   - name: "sid:2038150"
     description: "ET HUNTING HTTP GET Request XOR Key ba"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124535,8 +123606,7 @@ rules:
       to_server: true
   - name: "sid:2038151"
     description: "ET HUNTING HTTP GET Request XOR Key bb"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124547,8 +123617,7 @@ rules:
       to_server: true
   - name: "sid:2038211"
     description: "ET HUNTING HTTP GET Request XOR Key f8"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124570,8 +123639,7 @@ rules:
       to_server: true
   - name: "sid:2038106"
     description: "ET HUNTING HTTP GET Request XOR Key 8e"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124626,8 +123694,7 @@ rules:
       to_server: true
   - name: "sid:2038112"
     description: "ET HUNTING HTTP GET Request XOR Key 94"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124638,8 +123705,7 @@ rules:
       to_server: true
   - name: "sid:2038189"
     description: "ET HUNTING HTTP GET Request XOR Key e1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124650,8 +123716,7 @@ rules:
       to_server: true
   - name: "sid:2038200"
     description: "ET HUNTING HTTP GET Request XOR Key ed"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124662,8 +123727,7 @@ rules:
       to_server: true
   - name: "sid:2038155"
     description: "ET HUNTING HTTP GET Request XOR Key bf"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124696,8 +123760,7 @@ rules:
       to_server: true
   - name: "sid:2038105"
     description: "ET HUNTING HTTP GET Request XOR Key 8d"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124708,8 +123771,7 @@ rules:
       to_server: true
   - name: "sid:2038121"
     description: "ET HUNTING HTTP GET Request XOR Key 9d"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124797,8 +123859,7 @@ rules:
       to_server: true
   - name: "sid:2038217"
     description: "ET HUNTING HTTP GET Request XOR Key fe"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124842,8 +123903,7 @@ rules:
       to_server: true
   - name: "sid:2038104"
     description: "ET HUNTING HTTP GET Request XOR Key 8c"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124854,8 +123914,7 @@ rules:
       to_server: true
   - name: "sid:2038216"
     description: "ET HUNTING HTTP GET Request XOR Key fd"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124877,8 +123936,7 @@ rules:
       to_server: true
   - name: "sid:2038134"
     description: "ET HUNTING HTTP GET Request XOR Key aa"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124889,8 +123947,7 @@ rules:
       to_server: true
   - name: "sid:2038142"
     description: "ET HUNTING HTTP GET Request XOR Key b2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124901,8 +123958,7 @@ rules:
       to_server: true
   - name: "sid:2038125"
     description: "ET HUNTING HTTP GET Request XOR Key a1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124913,8 +123969,7 @@ rules:
       to_server: true
   - name: "sid:2038205"
     description: "ET HUNTING HTTP GET Request XOR Key f2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124925,8 +123980,7 @@ rules:
       to_server: true
   - name: "sid:2038135"
     description: "ET HUNTING HTTP GET Request XOR Key ab"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124937,8 +123991,7 @@ rules:
       to_server: true
   - name: "sid:2038184"
     description: "ET HUNTING HTTP GET Request XOR Key dc"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124949,8 +124002,7 @@ rules:
       to_server: true
   - name: "sid:2038129"
     description: "ET HUNTING HTTP GET Request XOR Key a5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124961,8 +124013,7 @@ rules:
       to_server: true
   - name: "sid:2038191"
     description: "ET HUNTING HTTP GET Request XOR Key e3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -124984,8 +124035,7 @@ rules:
       to_server: true
   - name: "sid:2038117"
     description: "ET HUNTING HTTP GET Request XOR Key 99"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -125007,8 +124057,7 @@ rules:
       to_server: true
   - name: "sid:2038140"
     description: "ET HUNTING HTTP GET Request XOR Key b0"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -125041,8 +124090,7 @@ rules:
       to_server: true
   - name: "sid:2038118"
     description: "ET HUNTING HTTP GET Request XOR Key 9a"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -125064,8 +124112,7 @@ rules:
       to_server: true
   - name: "sid:2038160"
     description: "ET HUNTING HTTP GET Request XOR Key c4"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -125076,8 +124123,7 @@ rules:
       to_server: true
   - name: "sid:2038193"
     description: "ET HUNTING HTTP GET Request XOR Key e6"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -125110,8 +124156,7 @@ rules:
       to_server: true
   - name: "sid:2038132"
     description: "ET HUNTING HTTP GET Request XOR Key a8"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -125133,8 +124178,7 @@ rules:
       to_server: true
   - name: "sid:2038181"
     description: "ET HUNTING HTTP GET Request XOR Key d9"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -125145,8 +124189,7 @@ rules:
       to_server: true
   - name: "sid:2038204"
     description: "ET HUNTING HTTP GET Request XOR Key f1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -125179,8 +124222,7 @@ rules:
       to_server: true
   - name: "sid:2038120"
     description: "ET HUNTING HTTP GET Request XOR Key 9c"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -125224,8 +124266,7 @@ rules:
       to_server: true
   - name: "sid:2038166"
     description: "ET HUNTING HTTP GET Request XOR Key ca"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -125697,8 +124738,7 @@ rules:
       to_client: true
   - name: "sid:2038601"
     description: "ET INFO SAFIB Assistant Remote Administration Tool Keepalive"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -125834,8 +124874,7 @@ rules:
       to_server: true
   - name: "sid:2033431"
     description: "ET HUNTING NOP Sled in HTTP URI Inbound - Possible Exploit Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:����)"
@@ -125852,8 +124891,7 @@ rules:
       case_insensitive: false
   - name: "sid:2038663"
     description: "ET MALWARE Win32/Caypnamer.A RAT CnC Keepalive"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -125964,8 +125002,7 @@ rules:
       to_server: true
   - name: "sid:2038708"
     description: "ET ADWARE_PUP ZeroTier P2P VPN Activity M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -126044,8 +125081,7 @@ rules:
       case_insensitive: false
   - name: "sid:2038735"
     description: "ET MALWARE Win32/Sabsik.EN.D!ml CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -126168,8 +125204,7 @@ rules:
       to_server: true
   - name: "sid:2038796"
     description: "ET MALWARE Win64/Spy.Agent.EU CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -126447,8 +125482,7 @@ rules:
       to_client: true
   - name: "sid:2038897"
     description: "ET MALWARE Warzone RAT Response (Inbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -126985,8 +126019,7 @@ rules:
       to_client: true
   - name: "sid:2036616"
     description: "ET MALWARE Win32/NetDooka Framework RAT Sending System Information M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -127037,8 +126070,7 @@ rules:
       to_server: true
   - name: "sid:2036614"
     description: "ET MALWARE Win32/NetDooka Framework RAT Sending System Information M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -127166,8 +126198,7 @@ rules:
       to_server: true
   - name: "sid:2039097"
     description: "ET HUNTING PNG in HTTP POST (Outbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:�PNG\\\r\\\n\u001a\\\n).{0,}(?-i:IHDR)"
@@ -127337,8 +126368,7 @@ rules:
       to_server: true
   - name: "sid:2039120"
     description: "ET MALWARE TrueBot/Silence.Downlaoder Screenshot Post M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:\\.php).*?(?-i:\\\r\\\nContent\\-Disposition:\\ form\\-data;\\ name=\"fileToUpload\";\\ filename=\").{0,50}(?-i:Content\\-Type:\\ application/octet\\-stream\\\r\\\n\\\r\\\n�PNG\\\r\\\n\u001a\\\n).*?(?-i:^[a-f0-9]{8}\\-[a-f0-9]{8}\\x22\\x0d\\x0a)"
@@ -127499,8 +126529,7 @@ rules:
       to_server: true
   - name: "sid:2039145"
     description: "ET EXPLOIT Possible Zimbra Arbitrary File Upload (CVE-2022-41352) M6"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�q).{0,100}(?-i:/jetty).{0,50}(?-i:/webapps/zimbra/public)"
@@ -127510,8 +126539,7 @@ rules:
       to_server: true
   - name: "sid:2039146"
     description: "ET EXPLOIT Possible Zimbra Arbitrary File Upload (CVE-2022-41352) M5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�q).{0,100}(?-i:\\\\jetty).{0,50}(?-i:\\\\webapps\\\\zimbra\\\\public)"
@@ -127521,8 +126549,7 @@ rules:
       to_server: true
   - name: "sid:2039147"
     description: "ET EXPLOIT Possible Zimbra Arbitrary File Upload (CVE-2022-41352) M7"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:����).{0,100}(?-i:\\\\jetty).{0,50}(?-i:\\\\webapps\\\\zimbra\\\\public)"
@@ -127532,8 +126559,7 @@ rules:
       to_server: true
   - name: "sid:2039148"
     description: "ET EXPLOIT Possible Zimbra Arbitrary File Upload (CVE-2022-41352) M8"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:����).{0,100}(?-i:/jetty).{0,50}(?-i:/webapps/zimbra/public)"
@@ -128485,8 +127511,7 @@ rules:
       to_client: true
   - name: "sid:2039784"
     description: "ET INFO ZeroTier Related Activity (udp)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -128502,8 +127527,7 @@ rules:
       exact: 137
   - name: "sid:2039800"
     description: "ET MALWARE Suspected Bitter APT Related Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -128822,8 +127846,7 @@ rules:
       to_server: true
   - name: "sid:2040134"
     description: "ET MALWARE Mustang Panda APT TONESHELL Related Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -129441,8 +128464,7 @@ rules:
       case_insensitive: false
   - name: "sid:2042189"
     description: "ET MALWARE Impersoni-fake-ator backdoor CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -129463,8 +128485,7 @@ rules:
       to_server: true
   - name: "sid:2042771"
     description: "ET MALWARE Win32/SocksTroy Session Initiation Attempt M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -129475,8 +128496,7 @@ rules:
       to_server: true
   - name: "sid:2042772"
     description: "ET MALWARE Win32/SocksTroy Session Initiation Attempt M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -129507,8 +128527,7 @@ rules:
       to_server: true
   - name: "sid:2042891"
     description: "ET MALWARE Win32/Sality.NBA Exfil"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -130830,8 +129849,7 @@ rules:
       case_insensitive: false
   - name: "sid:2043303"
     description: "ET MALWARE Win32/Spy.KeyLogger.RJA Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -131291,144 +130309,126 @@ rules:
       to_server: true
   - name: "sid:2027027"
     description: "ET ATTACK_RESPONSE UTF8 base64 string /This Program/ in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:hpcyBwcm9)"
       case_insensitive: false
   - name: "sid:2027028"
     description: "ET ATTACK_RESPONSE UTF8 base64 string /This Program/ in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:lzIHByb2d)"
       case_insensitive: false
   - name: "sid:2027029"
     description: "ET ATTACK_RESPONSE UTF8 base64 string /This Program/ in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:aXMgcHJvZ3J)"
       case_insensitive: false
   - name: "sid:2027030"
     description: "ET ATTACK_RESPONSE UTF16-LE base64 string /This Program/ in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:hpcyBwcm9ncm)"
       case_insensitive: false
   - name: "sid:2027031"
     description: "ET ATTACK_RESPONSE UTF16-LE base64 string /This Program/ in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:GlzIHByb2dyYW)"
       case_insensitive: false
   - name: "sid:2027032"
     description: "ET ATTACK_RESPONSE UTF16-LE base64 string /This Program/ in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:aXMgcHJvZ3JhbS)"
       case_insensitive: false
   - name: "sid:2027033"
     description: "ET ATTACK_RESPONSE UTF8 base64 wide string /This Program/ in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:gAaQBzACAAcAByAG8AZwByAGE)"
       case_insensitive: false
   - name: "sid:2027034"
     description: "ET ATTACK_RESPONSE UTF8 base64 wide string /This Program/ in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:BoAGkAcwAgAHAAcgBvAGcAcgB)"
       case_insensitive: false
   - name: "sid:2027035"
     description: "ET ATTACK_RESPONSE UTF8 base64 wide string /This Program/ in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:aABpAHMAIABwAHIAbwBnAHIAYQB)"
       case_insensitive: false
   - name: "sid:2027036"
     description: "ET ATTACK_RESPONSE UTF16-LE base64 wide string /This Program/ in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:BoAGkAcwAgAHAAcgBvAGcAcgBhAG)"
       case_insensitive: false
   - name: "sid:2027037"
     description: "ET ATTACK_RESPONSE UTF16-LE base64 wide string /This Program/ in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:GgAaQBzACAAcAByAG8AZwByAGEAbQ)"
       case_insensitive: false
   - name: "sid:2027038"
     description: "ET ATTACK_RESPONSE UTF16-LE base64 wide string /This Program/ in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:aABpAHMAIABwAHIAbwBnAHIAYQBtAC)"
       case_insensitive: false
   - name: "sid:2027039"
     description: "ET ATTACK_RESPONSE UTF8 base64 reversed string /This Program/ in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:FyZ29ycCB)"
       case_insensitive: false
   - name: "sid:2027040"
     description: "ET ATTACK_RESPONSE UTF8 base64 reversed string /This Program/ in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:1hcmdvcnA)"
       case_insensitive: false
   - name: "sid:2027041"
     description: "ET ATTACK_RESPONSE UTF8 base64 reversed string /This Program/ in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:YXJnb3JwIHN)"
       case_insensitive: false
   - name: "sid:2027042"
     description: "ET ATTACK_RESPONSE UTF16 base64 reversed string /This Program/ in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:1hcmdvcnAgc2)"
       case_insensitive: false
   - name: "sid:2027043"
     description: "ET ATTACK_RESPONSE UTF16 base64 reversed string /This Program/ in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:WFyZ29ycCBzaW)"
       case_insensitive: false
   - name: "sid:2027044"
     description: "ET ATTACK_RESPONSE UTF16 base64 reversed string /This Program/ in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:YXJnb3JwIHNpaF)"
@@ -131567,8 +130567,7 @@ rules:
       to_server: true
   - name: "sid:2043753"
     description: "ET MALWARE Win32/HMR RAT Sending System Information"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -131758,8 +130757,7 @@ rules:
       exact: 36
   - name: "sid:2044065"
     description: "ET MALWARE Kakfum/COLDSTEEL CnC Beacon M3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -131772,8 +130770,7 @@ rules:
       to_server: true
   - name: "sid:2044069"
     description: "ET INFO RustDesk Check NAT Type"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -131815,8 +130812,7 @@ rules:
       exact: 15
   - name: "sid:2044072"
     description: "ET INFO RustDesk Get Software Update URL"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -131851,8 +130847,7 @@ rules:
       case_insensitive: false
   - name: "sid:2044075"
     description: "ET INFO RustDesk Peer Discovery (ping)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -131872,8 +130867,7 @@ rules:
       case_insensitive: false
   - name: "sid:2044062"
     description: "ET MALWARE UAC-0114/Winter Vivern Screenshot Upload M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:\\.php).*?(?-i:cUsers/).{0,}(?-i:Microsoft_update_tool_).{0,7}(?-i:\\.dat\\\r\\\n).*?(?-i:�PNG\\\r\\\n\u001a\\\n)"
@@ -132030,8 +131024,7 @@ rules:
       case_insensitive: false
   - name: "sid:2044123"
     description: "ET MALWARE NginxSpy Magic Bytes M2 (Inbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -132045,8 +131038,7 @@ rules:
         flag: "ET.nginxspy"
   - name: "sid:2044124"
     description: "ET MALWARE NginxSpy Magic Bytes M1 (Outbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -132182,8 +131174,7 @@ rules:
       case_insensitive: false
   - name: "sid:2044196"
     description: "ET MALWARE zgRAT Activity M3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -132390,8 +131381,7 @@ rules:
       to_server: true
   - name: "sid:2044249"
     description: "ET MALWARE Win32/Stealc Submitting Screenshot to C2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:\\.php).*?(?-i:form\\-data;\\ name=\"token\").{0,}(?-i:form\\-data;\\ name=\"file\"\\\r\\\n\\\r\\\n).*?(?-i:���).{3,4}(?-i:JFIF)"
@@ -133162,8 +132152,7 @@ rules:
       to_server: true
   - name: "sid:2044452"
     description: "ET ADWARE_PUP Win32/Pearfoos.B!ml Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -133247,8 +132236,7 @@ rules:
       to_client: true
   - name: "sid:2044553"
     description: "ET MALWARE Win32/Packed.BlackMoon.A Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -133455,8 +132443,7 @@ rules:
       case_insensitive: false
   - name: "sid:2044574"
     description: "ET MALWARE Win32/HMR RAT Sending System Information M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -133480,8 +132467,7 @@ rules:
       to_client: true
   - name: "sid:2044595"
     description: "ET MALWARE Win32/HMR RAT Sending System Information M3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -133495,8 +132481,7 @@ rules:
       to_server: true
   - name: "sid:2044596"
     description: "ET MALWARE Win32/HMR RAT Sending System Information M4"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -133711,8 +132696,7 @@ rules:
       to_server: true
   - name: "sid:2044628"
     description: "ET MALWARE SideCopy APT Related Backdoor Command Inbound (getinfo)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -133888,8 +132872,7 @@ rules:
       case_insensitive: false
   - name: "sid:2044677"
     description: "ET MALWARE Fortigate TABLEFLIP Backdoor Trigger - Magic Number Sequence"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -134098,8 +133081,7 @@ rules:
       case_insensitive: false
   - name: "sid:2044756"
     description: "ET ADWARE_PUP Win32/Packed.FlyStudio.AA Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -134406,8 +133388,7 @@ rules:
       case_insensitive: false
   - name: "sid:2044843"
     description: "ET MALWARE OpcJacker HVNC Variant Magic Packet"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -135614,8 +134595,7 @@ rules:
       to_client: true
   - name: "sid:2001330"
     description: "ET INFO RDP - Response To External Host"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -135701,8 +134681,7 @@ rules:
       case_insensitive: false
   - name: "sid:2045211"
     description: "ET MALWARE Suspected Win32/HMR RAT/LOBSHOT Initial Handshake"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -135725,64 +134704,56 @@ rules:
       case_insensitive: false
   - name: "sid:2044680"
     description: "ET EXPLOIT Possible Microsoft Outlook Elevation of Privilege Payload Observed M1 (CVE-2023-23397)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:AElQTS5UYXNr).*?(?-i:\\\r\\\n\\\r\\\n).*?(?-i:x�>\").*?(?-i:I\u0000P\u0000M\u0000\\.\u0000T\u0000a\u0000s\u0000k).*?(?-i:\\\\).*?(?-i:^\\x00?\\\\\\x00?[\\w\\.\\-\\x00]+\\\\)"
       case_insensitive: false
   - name: "sid:2044681"
     description: "ET EXPLOIT Possible Microsoft Outlook Elevation of Privilege Payload Observed M2 (CVE-2023-23397)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:SVBNLk1pY3Jvc29mdCBNYWlsLk5vdG).*?(?-i:\\\r\\\n\\\r\\\n).*?(?-i:x�>\").*?(?-i:IPM\\.Microsoft\\ Mail\\.Note).*?(?-i:\\\\).*?(?-i:^\\x00?\\\\\\x00?[\\w\\.\\-\\x00]+\\\\)"
       case_insensitive: false
   - name: "sid:2044682"
     description: "ET EXPLOIT Possible Microsoft Outlook Elevation of Privilege Payload Observed M3 (CVE-2023-23397)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:AElQTS5UYXNr).*?(?-i:\\\r\\\n\\\r\\\n).*?(?-i:x�>\").*?(?-i:\u0000IPM\\.Task).*?(?-i:\\\\).*?(?-i:^\\x00?\\\\\\x00?[\\w\\.\\-\\x00]+\\\\)"
       case_insensitive: false
   - name: "sid:2044683"
     description: "ET EXPLOIT Possible Microsoft Outlook Elevation of Privilege Payload Observed M4 (CVE-2023-23397)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:SQBQAE0ALgBNAGkAYwByAG8AcwBvAGYAdAAgAE0AYQBpAGwALgBOAG8AdABlA).*?(?-i:\\\r\\\n\\\r\\\n).*?(?-i:x�>\").*?(?-i:I\u0000P\u0000M\u0000\\.\u0000M\u0000i\u0000c\u0000r\u0000o\u0000s\u0000o\u0000f\u0000t\u0000\\ \u0000M\u0000a\u0000i\u0000l\u0000\\.\u0000N\u0000o\u0000t\u0000e).*?(?-i:\\\\).*?(?-i:^\\x00?\\\\\\x00?[\\w\\.\\-\\x00]+\\\\)"
       case_insensitive: false
   - name: "sid:2044684"
     description: "ET EXPLOIT Possible Microsoft Outlook Elevation of Privilege Payload Observed M5 (CVE-2023-23397)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:AElQTS5UYXNr).*?(?-i:\\\r\\\n\\\r\\\n).*?(?-i:x�>\").*?(?-i:\u0000IPM\\.Task).*?(?-i:\\\\).*?(?-i:^\\x00?\\\\\\x00?[\\w\\.\\-\\x00]+\\\\)"
       case_insensitive: false
   - name: "sid:2044685"
     description: "ET EXPLOIT Possible Microsoft Outlook Elevation of Privilege Payload Observed M6 (CVE-2023-23397)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:SQBQAE0ALgBUAGEAcwBrA).*?(?-i:\\\r\\\n\\\r\\\n).*?(?-i:x�>\").*?(?-i:\u0000I\u0000P\u0000M\u0000\\.\u0000T\u0000a\u0000s\u0000k).*?(?-i:\\\\).*?(?-i:^\\x00?\\\\\\x00?[\\w\\.\\-\\x00]+\\\\)"
       case_insensitive: false
   - name: "sid:2044686"
     description: "ET EXPLOIT Possible Microsoft Outlook Elevation of Privilege Payload Observed M7 (CVE-2023-23397)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:SQBQAE0ALgBNAGkAYwByAG8AcwBvAGYAdAAgAE0AYQBpAGwALgBOAG8AdABlA).*?(?-i:\\\r\\\n\\\r\\\n).*?(?-i:x�>\").*?(?-i:I\u0000P\u0000M\u0000\\.\u0000M\u0000i\u0000c\u0000r\u0000o\u0000s\u0000o\u0000f\u0000t\u0000\\ \u0000M\u0000a\u0000i\u0000l\u0000\\.\u0000N\u0000o\u0000t\u0000e).*?(?-i:\\\\).*?(?-i:^\\x00?\\\\\\x00?[\\w\\.\\-\\x00]+\\\\)"
       case_insensitive: false
   - name: "sid:2044687"
     description: "ET EXPLOIT Possible Microsoft Outlook Elevation of Privilege Payload Observed M8 (CVE-2023-23397)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:SVBNLk1pY3Jvc29mdCBNYWlsLk5vdG).*?(?-i:\\\r\\\n\\\r\\\n).*?(?-i:x�>\").*?(?-i:IPM\\.Microsoft\\ Mail\\.Note).*?(?-i:\\\\).*?(?-i:^\\x00?\\\\\\x00?[\\w\\.\\-\\x00]+\\\\)"
@@ -136300,8 +135271,7 @@ rules:
       to_client: true
   - name: "sid:2025008"
     description: "ET INFO PTsecurity Remote Desktop AeroAdmin Server Hello"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -136317,8 +135287,7 @@ rules:
       to_client: true
   - name: "sid:2025009"
     description: "ET INFO PTsecurity Remote Desktop AeroAdmin handshake"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -137255,8 +136224,7 @@ rules:
       to_server: true
   - name: "sid:2046045"
     description: "ET MALWARE [ANY.RUN] RedLine Stealer/MetaStealer Family Related (MC-NMF Authorization)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -137517,8 +136485,7 @@ rules:
       to_server: true
   - name: "sid:2046159"
     description: "ET SCADA IEC-104 TESTFR (Test Frame) Confirmation"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -137701,8 +136668,7 @@ rules:
       to_server: true
   - name: "sid:2046164"
     description: "ET SCADA IEC-104 Station Interrogation - Global ASDU Broadcast"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -139127,8 +138093,7 @@ rules:
       to_server: true
   - name: "sid:2046751"
     description: "ET MALWARE [ANY.RUN] Hydrochasma Fast Reverse Proxy M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -140589,8 +139554,7 @@ rules:
       to_server: true
   - name: "sid:2047156"
     description: "ET MALWARE [ANY.RUN] Parallax RAT Check-In"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -142011,8 +140975,7 @@ rules:
       to_server: true
   - name: "sid:2048086"
     description: "ET MOBILE_MALWARE Android/MMRAT CnC Checkin M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -142171,8 +141134,7 @@ rules:
       to_server: true
   - name: "sid:2048128"
     description: "ET MALWARE Win32/Gh0stRat C2 Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -142183,8 +141145,7 @@ rules:
       to_server: true
   - name: "sid:2048129"
     description: "ET MALWARE Win32/Gh0stRat C2 Response (X11 SelectionNotify)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -142747,8 +141708,7 @@ rules:
         flag: "ET.CVE-2023-42793"
   - name: "sid:2048477"
     description: "ET MALWARE [ANY.RUN] Win32/Gh0stRat Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -142759,8 +141719,7 @@ rules:
       to_server: true
   - name: "sid:2048478"
     description: "ET MALWARE [ANY.RUN] Win32/Gh0stRat Keep-Alive"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -144019,8 +142978,7 @@ rules:
         flag: "ET.easystealer"
   - name: "sid:2048900"
     description: "ET MALWARE [ANY.RUN] zgRAT / PureLogs Stealer Data Exfiltration Attempt M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -144466,8 +143424,7 @@ rules:
       to_server: true
   - name: "sid:2049034"
     description: "ET MALWARE SockRacket/KANDYKORN Client Connect (Random Number)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -144480,8 +143437,7 @@ rules:
       to_server: true
   - name: "sid:2049035"
     description: "ET MALWARE SockRacket/KANDYKORN CnC Response (Nonce)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -144494,8 +143450,7 @@ rules:
       to_client: true
   - name: "sid:2049036"
     description: "ET MALWARE SockRacket/KANDYKORN Client Challenge"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -144511,8 +143466,7 @@ rules:
         flag: "ET.SockRacketClientChallenge"
   - name: "sid:2049037"
     description: "ET MALWARE SockRacket/KANDYKORN CnC Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -144846,8 +143800,7 @@ rules:
         flag: "ET.Socks5Systemz.Checkin"
   - name: "sid:2049123"
     description: "ET MALWARE Bandit Stealer Host Details Exfil"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:████�).*?(?-i:Username:\\ ).*?(?-i:Computer\\ Name:\\ ).*?(?-i:IP\\ Address:\\ ).*?(?-i:OS\\ Name:\\ ).*?(?-i:Processor\\(s\\):)"
@@ -145410,8 +144363,7 @@ rules:
       case_insensitive: false
   - name: "sid:2049295"
     description: "ET EXPLOIT SysAid Traversal Attack (CVE-2023-47246)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?i:/userentry\\?accountId=).*?(?-i:x�).*?(?i:^[^&]+\\x2e(?:\\x2e|\\x2f))"
@@ -145451,8 +144403,7 @@ rules:
       to_server: true
   - name: "sid:2049394"
     description: "ET MALWARE Marai Variant Activity (Inbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -145502,8 +144453,7 @@ rules:
       to_client: true
   - name: "sid:2049397"
     description: "ET MALWARE [ANY.RUN] Socks5Systemz TCP Backconnect Client Traffic"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -145679,8 +144629,7 @@ rules:
       to_client: true
   - name: "sid:2049409"
     description: "ET MALWARE SugarGh0st RAT CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -147426,8 +146375,7 @@ rules:
       to_server: true
   - name: "sid:2049795"
     description: "ET SCADA Rockwell RNA Message Large Header Length - 8Kb"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -147501,8 +146449,7 @@ rules:
       to_server: true
   - name: "sid:2049873"
     description: "ET MALWARE Kimsuky APT Related Win32/RftRAT Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -152164,8 +151111,7 @@ rules:
       to_client: true
   - name: "sid:2049660"
     description: "ET MALWARE RisePro CnC Activity (Outbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -152176,8 +151122,7 @@ rules:
       to_client: true
   - name: "sid:2049060"
     description: "ET MALWARE RisePro TCP Heartbeat Packet"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -152191,8 +151136,7 @@ rules:
       to_server: true
   - name: "sid:2049661"
     description: "ET MALWARE RisePro CnC Activity (Inbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -152247,8 +151191,7 @@ rules:
       to_server: true
   - name: "sid:2050066"
     description: "ET MALWARE Hailbot CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -152353,8 +151296,7 @@ rules:
         flag: "ET.BackConnect"
   - name: "sid:2050080"
     description: "ET MALWARE BackConnect CnC Activity (Bot Task Request) M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -152370,8 +151312,7 @@ rules:
         flag: "ET.BackConnect"
   - name: "sid:2050082"
     description: "ET MALWARE BackConnect CnC Activity (Bot Error) M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -152387,8 +151328,7 @@ rules:
         flag: "ET.BackConnect"
   - name: "sid:2050084"
     description: "ET MALWARE BackConnect CnC Activity (Start SOCKS) M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -152404,8 +151344,7 @@ rules:
         flag: "ET.BackConnect"
   - name: "sid:2050085"
     description: "ET MALWARE BackConnect CnC Activity (Start SOCKS) M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -152421,8 +151360,7 @@ rules:
         flag: "ET.BackConnect"
   - name: "sid:2050086"
     description: "ET MALWARE BackConnect CnC Activity (Start VNC) M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -152438,8 +151376,7 @@ rules:
         flag: "ET.BackConnect"
   - name: "sid:2050087"
     description: "ET MALWARE BackConnect CnC Activity (Start VNC) M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -152455,8 +151392,7 @@ rules:
         flag: "ET.BackConnect"
   - name: "sid:2050088"
     description: "ET MALWARE BackConnect CnC Activity (Start VNC) M3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -152472,8 +151408,7 @@ rules:
         flag: "ET.BackConnect"
   - name: "sid:2050089"
     description: "ET MALWARE BackConnect CnC Activity (Start VNC) M4"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -152489,8 +151424,7 @@ rules:
         flag: "ET.BackConnect"
   - name: "sid:2050090"
     description: "ET MALWARE BackConnect CnC Activity (Start File Manager) M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -152506,8 +151440,7 @@ rules:
         flag: "ET.BackConnect"
   - name: "sid:2050091"
     description: "ET MALWARE BackConnect CnC Activity (Start File Manager) M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -152523,8 +151456,7 @@ rules:
         flag: "ET.BackConnect"
   - name: "sid:2050092"
     description: "ET MALWARE BackConnect CnC Activity (Start Reverse Shell) M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -152540,8 +151472,7 @@ rules:
         flag: "ET.BackConnect"
   - name: "sid:2050093"
     description: "ET MALWARE BackConnect CnC Activity (Start Reverse Shell) M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -153070,8 +152001,7 @@ rules:
       to_client: true
   - name: "sid:2050432"
     description: "ET HUNTING External SMB ANDX Request for Outlook Calendar Invite File (.ics) - Possible NTLM Hash Leak Attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,4}(?-i:�SMB).*?(?i:\u0000\\.\u0000i\u0000c\u0000s\u0000\u0000\u0000)"
@@ -153162,8 +152092,7 @@ rules:
       to_server: true
   - name: "sid:2050497"
     description: "ET MALWARE nspx30 Backdoor Trigger Response Observed"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -153710,8 +152639,7 @@ rules:
       to_server: true
   - name: "sid:2046950"
     description: "ET MALWARE [ANY.RUN] Hydrochasma Fast Reverse Proxy M3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -153742,8 +152670,7 @@ rules:
       to_client: true
   - name: "sid:2050079"
     description: "ET MALWARE BackConnect CnC Activity (Bot Task Request) M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -153759,8 +152686,7 @@ rules:
         flag: "ET.BackConnect"
   - name: "sid:2050081"
     description: "ET MALWARE BackConnect CnC Activity (Bot Error) M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -155400,8 +154326,7 @@ rules:
       case_insensitive: false
   - name: "sid:2050979"
     description: "ET HUNTING - DNS Response containing multiple DNSSEC RRSIG Entries (Algorithm 14) - Possible CVE-2023-50387 Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -156346,8 +155271,7 @@ rules:
       to_server: true
   - name: "sid:2051153"
     description: "ET MALWARE TA430/Andariel NukeSped Backdoor Variant Activity M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -156363,8 +155287,7 @@ rules:
         flag: "ET.Nukesped"
   - name: "sid:2051154"
     description: "ET MALWARE TA430/Andariel NukeSped Backdoor Variant Activity M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -156380,8 +155303,7 @@ rules:
         flag: "ET.Nukesped"
   - name: "sid:2051155"
     description: "ET MALWARE TA430/Andariel NukeSped Backdoor Variant Server Response M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -156397,8 +155319,7 @@ rules:
         flag: "ET.Nukesped"
   - name: "sid:2051156"
     description: "ET MALWARE TA430/Andariel NukeSped Backdoor Variant Server Response M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -159652,8 +158573,7 @@ rules:
       to_server: true
   - name: "sid:2008274"
     description: "ET MALWARE Bifrose Response from Controller"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -161315,8 +160235,7 @@ rules:
       to_client: true
   - name: "sid:2009557"
     description: "ET MALWARE Yoda's Protector Packed Binary - VERY Likely Hostile"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -162437,8 +161356,7 @@ rules:
       to_client: true
   - name: "sid:2010494"
     description: "ET SCAN Multiple MySQL Login Failures Possible Brute Force Attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -163439,8 +162357,7 @@ rules:
       to_server: true
   - name: "sid:2012084"
     description: "ET NETBIOS Microsoft Windows SMB Client Race Condition Remote Code Execution"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -163464,8 +162381,7 @@ rules:
       to_client: true
   - name: "sid:2012094"
     description: "ET NETBIOS SMB Trans2 Query_Fs_Attribute_Info SrvSmbQueryFsInformation Pool Buffer Overflow"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -163560,8 +162476,7 @@ rules:
       to_server: true
   - name: "sid:2012711"
     description: "ET INFO MS Remote Desktop POS User Login Request"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -163575,8 +162490,7 @@ rules:
       to_server: true
   - name: "sid:2012712"
     description: "ET INFO MS Remote Desktop Service User Login Request"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -163600,8 +162514,7 @@ rules:
       to_server: true
   - name: "sid:2012842"
     description: "ET MALWARE Backdoor.Win32.Xyligan Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -164193,8 +163106,7 @@ rules:
       to_server: true
   - name: "sid:2013891"
     description: "ET MALWARE Backdoor.Win32.Svlk Client Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -164466,8 +163378,7 @@ rules:
       to_server: true
   - name: "sid:2014228"
     description: "ET MALWARE Backdoor Win32.Idicaf/Atraps"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -164493,8 +163404,7 @@ rules:
       to_server: true
   - name: "sid:2014272"
     description: "ET MALWARE Win32/Cutwail.BE Checkin 2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -164749,8 +163659,7 @@ rules:
       to_server: true
   - name: "sid:2014955"
     description: "ET MALWARE Backdoor Win32/Hupigon.CK Client Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -164761,8 +163670,7 @@ rules:
       to_server: true
   - name: "sid:2014956"
     description: "ET MALWARE Backdoor Win32/Hupigon.CK Server Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -164773,8 +163681,7 @@ rules:
       to_client: true
   - name: "sid:2014958"
     description: "ET MALWARE Backdoor Win32/Hupigon.CK Server Idle"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -164815,8 +163722,7 @@ rules:
       to_server: true
   - name: "sid:2015595"
     description: "ET MALWARE FinFisher Malware Connection Handshake"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -164827,8 +163733,7 @@ rules:
       to_server: true
   - name: "sid:2015686"
     description: "ET INFO Signed TLS Certificate with md5WithRSAEncryption"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,0}(?-i:\u0016\u0003\u0001).{1,2}(?-i:\u0002).{0,3}(?-i:\u0016\u0003\u0001).{2}(?-i:\\\u000b).{2,9}(?-i:0�).{2}(?-i:0�).{2,6}(?-i:�\u0003\u0002\u0001\u0002\u0002).{0,15}(?-i:0\\\r\u0006\\\t\\*�H��\\\r\u0001\u0001\u0004\u0005\u0000)"
@@ -165034,8 +163939,7 @@ rules:
       to_server: true
   - name: "sid:2016398"
     description: "ET MALWARE Trojan.APT.9002 CnC Traffic"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -165762,8 +164666,7 @@ rules:
       to_server: true
   - name: "sid:2016986"
     description: "ET MALWARE KeyBoy Backdoor Login"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -166336,8 +165239,7 @@ rules:
       to_server: true
   - name: "sid:2017816"
     description: "ET MALWARE Possible Upatre Downloader SSL certificate"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\\*�H��\\\r\u0001\\\t\u0001).*?(?-i:^.{2}(?P<fake_email>([asdfgh]+|[qwerty]+|[zxcvbn]+)\\@([asdfgh]+|[qwerty]+|[zxcvbn]+)\\.).+?\\x2a\\x86\\x48\\x86\\xf7\\x0d\\x01\\x09\\x01.{2}(?P=fake_email))"
@@ -166449,8 +165351,7 @@ rules:
       to_client: true
   - name: "sid:2018116"
     description: "ET MALWARE MS Remote Desktop edc User Login Request"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -166464,8 +165365,7 @@ rules:
       to_server: true
   - name: "sid:2018124"
     description: "ET MALWARE MS Remote Desktop micros User Login Request"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -166479,8 +165379,7 @@ rules:
       to_server: true
   - name: "sid:2018130"
     description: "ET MALWARE W32/Trojan-Gypikon Server Check-in Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -166506,8 +165405,7 @@ rules:
       to_server: true
   - name: "sid:2018154"
     description: "ET MALWARE Win32.Hack.PcClient.g CnC (OUTBOUND) XOR b5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -166637,8 +165535,7 @@ rules:
       to_server: true
   - name: "sid:2018229"
     description: "ET MALWARE Darkshell.A Checkin XOR C0 Win XP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -166723,8 +165620,7 @@ rules:
       to_server: true
   - name: "sid:2018390"
     description: "ET MALWARE Backdoor Win32/Zegost.Q CnC traffic (OUTBOUND)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -166791,8 +165687,7 @@ rules:
       to_server: true
   - name: "sid:2018615"
     description: "ET MALWARE Win32/Sharik C2 Incoming Traffic"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -166949,8 +165844,7 @@ rules:
       to_server: true
   - name: "sid:2019208"
     description: "ET MALWARE Linux/BillGates Checkin Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -167079,8 +165973,7 @@ rules:
       to_server: true
   - name: "sid:2019313"
     description: "ET MALWARE Sourtoff Receiving Simda Payload"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -167326,8 +166219,7 @@ rules:
       to_server: true
   - name: "sid:2019587"
     description: "ET MALWARE W32/ZxShell Server Checkin Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -167470,8 +166362,7 @@ rules:
       to_server: true
   - name: "sid:2020007"
     description: "ET MALWARE US-CERT TA14-353A Lightweight Backdoor 1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -167485,8 +166376,7 @@ rules:
       to_client: true
   - name: "sid:2020011"
     description: "ET MALWARE US-CERT TA14-353A Lightweight Backdoor 5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -167533,8 +166423,7 @@ rules:
         flag: "ET.Misfortune_Cookie"
   - name: "sid:2020155"
     description: "ET MALWARE Win32/Recslurp.D C2 Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -167581,8 +166470,7 @@ rules:
       to_client: true
   - name: "sid:2020173"
     description: "ET MALWARE Skeleton Key Filename in SMB Traffic (ASCII)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -167606,8 +166494,7 @@ rules:
       to_server: true
   - name: "sid:2020174"
     description: "ET MALWARE Skeleton Key Filename in SMB Traffic (ASCII)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -167631,8 +166518,7 @@ rules:
       to_server: true
   - name: "sid:2020175"
     description: "ET MALWARE Skeleton Key Filename in SMB Traffic (ASCII)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -167656,8 +166542,7 @@ rules:
       to_server: true
   - name: "sid:2020176"
     description: "ET MALWARE Skeleton Key Filename in SMB Traffic (Unicode)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -167681,8 +166566,7 @@ rules:
       to_server: true
   - name: "sid:2020177"
     description: "ET MALWARE Skeleton Key Filename in SMB Traffic (Unicode)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -167706,8 +166590,7 @@ rules:
       to_server: true
   - name: "sid:2020178"
     description: "ET MALWARE Skeleton Key Filename in SMB Traffic (Unicode)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -167779,8 +166662,7 @@ rules:
       to_server: true
   - name: "sid:2020310"
     description: "ET MALWARE Regin Hopscotch Module Accessing SMB Named Pipe (Unicode) 2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -167899,8 +166781,7 @@ rules:
       to_server: true
   - name: "sid:2020585"
     description: "ET EXPLOIT PCMan FTP Server 2.0.7 Remote Command Execution"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:e��\\|).{0,10}(?-i:�����)"
@@ -168144,8 +167025,7 @@ rules:
       to_client: true
   - name: "sid:2021049"
     description: "ET MALWARE Linux/DDoS.Sotdas/IptabLex Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -168195,8 +167075,7 @@ rules:
       to_server: true
   - name: "sid:2021066"
     description: "ET VOIP Possible Misuse Call from Cisco ooh323"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -168783,8 +167662,7 @@ rules:
       to_server: true
   - name: "sid:2022022"
     description: "ET VOIP Possible Misuse Call from MERA RTU"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -168918,8 +167796,7 @@ rules:
       to_server: true
   - name: "sid:2022116"
     description: "ET EXPLOIT Serialized Java Object Generated by ysoserial"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -168930,8 +167807,7 @@ rules:
       to_server: true
   - name: "sid:2022117"
     description: "ET EXPLOIT Serialized Groovy Java Object Generated by ysoserial"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -168942,8 +167818,7 @@ rules:
       to_server: true
   - name: "sid:2022118"
     description: "ET EXPLOIT Serialized Spring Java Object Generated by ysoserial"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -169311,8 +168186,7 @@ rules:
       to_client: true
   - name: "sid:2022637"
     description: "ET MALWARE Possible Locky Ransomware Writing Encrypted File over - SMB and SMB-DS v1 Unicode"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -169336,8 +168210,7 @@ rules:
       to_server: true
   - name: "sid:2022638"
     description: "ET MALWARE Possible Locky Ransomware Writing Encrypted File over - SMB and SMB-DS v1 ASCII"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -169361,8 +168234,7 @@ rules:
       to_server: true
   - name: "sid:2022639"
     description: "ET MALWARE Possible Locky Ransomware Writing Encrypted File over - SMB and SMB-DS v2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -169447,8 +168319,7 @@ rules:
       to_server: true
   - name: "sid:2022838"
     description: "ET MALWARE Possible CryptXXX Ransomware Renaming Encrypted File SMB v1 Unicode"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -169472,8 +168343,7 @@ rules:
       to_server: true
   - name: "sid:2022839"
     description: "ET MALWARE Possible CryptXXX Ransomware Renaming Encrypted File SMB v1 ASCII"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -169497,8 +168367,7 @@ rules:
       to_server: true
   - name: "sid:2022840"
     description: "ET MALWARE Possible CryptXXX Ransomware Renaming Encrypted File SMB v2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -169906,8 +168775,7 @@ rules:
       to_client: true
   - name: "sid:2023147"
     description: "ET MALWARE Locky Ransomware Renaming File via SMB"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -169921,8 +168789,7 @@ rules:
       to_server: true
   - name: "sid:2023148"
     description: "ET MALWARE Locky Ransomware Writing Instructions via SMB"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -169936,8 +168803,7 @@ rules:
       to_server: true
   - name: "sid:2023149"
     description: "ET MALWARE Zlader Ransomware Worm Propagating Over SMB v1 ASCII"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -170713,8 +169579,7 @@ rules:
       to_client: true
   - name: "sid:2023753"
     description: "ET SCAN MS Terminal Server Traffic on Non-standard Port"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -170941,8 +169806,7 @@ rules:
       to_server: true
   - name: "sid:2023831"
     description: "ET DOS Excessive Large Tree Connect Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -170966,8 +169830,7 @@ rules:
       to_client: true
   - name: "sid:2023832"
     description: "ET DOS SMB Tree_Connect Stack Overflow Attempt (CVE-2017-0016)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -171216,8 +170079,7 @@ rules:
       to_server: true
   - name: "sid:2024194"
     description: "ET EXPLOIT Cisco Catalyst Remote Code Execution (CVE-2017-3881)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -171241,8 +170103,7 @@ rules:
       to_client: true
   - name: "sid:2024207"
     description: "ET EXPLOIT Possible Successful ETERNALROMANCE MS17-010 - Windows Executable Observed"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,4}(?-i:�SMB\\&\u0000\u0000\u0000\u0000).{0,}(?-i:MZ).{0,}(?i:This\\ program\\ cannot\\ be\\ run)"
@@ -171255,8 +170116,7 @@ rules:
         flag: "ETPRO.ETERNALROMANCE"
   - name: "sid:2024213"
     description: "ET EXPLOIT Possible ETERNALCHAMPION MS17-010 Sync Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,4}(?-i:�SMB%\u0000\u0000\u0000\u0000�\u0003�\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000).{2,32}(?-i:\\|\u0000).{0,20}(?-i:\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000).{20,100}(?-i:\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000).{20,100}(?-i:\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000).{20,100}(?-i:\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000).*?(?-i:\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000)"
@@ -171269,8 +170129,7 @@ rules:
         flag: "ET.ETERNALCHAMPIONsync"
   - name: "sid:2024214"
     description: "ET EXPLOIT Possible ECLIPSEDWING RPCTOUCH MS08-067"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,4}(?-i:�SMB/\u0000\u0000\u0000\u0000).{0,}(?-i:NTLMSSP\u0000\u0003\u0000\u0000\u0000\u0001\u0000\u0001\u0000).{4,8}(?-i:\u0000\u0000\u0000\u0000I\u0000\u0000\u0000).{0,8}(?-i:\u0000\u0000\u0000\u0000H\u0000\u0000\u0000).{0,8}(?-i:\u0000\u0000\u0000\u0000H\u0000\u0000\u0000).{0,8}(?-i:\u0000\u0000\u0000\u0000H\u0000\u0000\u0000).{0,8}(?-i:\u0000\u0000\u0000\u0000I\u0000\u0000\u0000).{4,9}(?-i:\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000)"
@@ -171280,8 +170139,7 @@ rules:
       to_server: true
   - name: "sid:2024215"
     description: "ET EXPLOIT Possible ECLIPSEDWING MS08-067"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,4}(?-i:�SMB/\u0000\u0000\u0000\u0000).{10,30}(?-i:\u0000\u0000\u0000\u0000����\u0008\u0000).{0,}(?-i:\\.\u0000\u0000\u0000\u0000\u0000\u0000\u0000\\.\u0000\u0000\u0000).{0,12}(?-i:/\u0000A\u0000/\u0000\\.\u0000\\.\u0000/\u0000).{0,}(?-i:\\.\u0000\u0000\u0000\u0000\u0000\u0000\u0000\\.\u0000\u0000\u0000).{0,12}(?-i:/\u0000A\u0000/\u0000\\.\u0000\\.\u0000/\u0000).{0,}(?-i:/\u0000A\u0000/\u0000\\.\u0000\\.\u0000/\u0000).{0,}(?-i:/\u0000A\u0000/\u0000\\.\u0000\\.\u0000/\u0000)"
@@ -171291,8 +170149,7 @@ rules:
       to_server: true
   - name: "sid:2024216"
     description: "ET EXPLOIT Possible DOUBLEPULSAR Beacon Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,0}(?-i:\u0000\u0000\u0000\\#�SMB2\u0002\u0000\u0000��\u0007�\u0000\u0000).{8}(?-i:\u0000\u0000\u0000\u0008��\u0000\u0008).{1,3}(?-i:\u0000\u0000\u0000).*?(?-i:^[\\x50-\\x59])"
@@ -171302,8 +170159,7 @@ rules:
       to_client: true
   - name: "sid:2024217"
     description: "ET EXPLOIT Possible ETERNALBLUE MS17-010 Heap Spray"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,4}(?-i:�SMB3\u0000\u0000\u0000\u0000\u0018\u0007�\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0008��\u0000\u0008).{1,6}(?-i:\u0000\\\t\u0000\u0000\u0000\u0010).{0,8}(?-i:\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0010).{4}(?-i:\u0000\u0000\u0000\u0010).*?(?-i:^[a-zA-Z0-9+/]{1000,})"
@@ -171313,8 +170169,7 @@ rules:
       to_server: true
   - name: "sid:2024219"
     description: "ET EXPLOIT Possible ETERNALROMANCE MS17-010 Heap Spray"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,4}(?-i:�SMB%\u0000\u0000\u0000\u0000\u0018).{0,16}(?-i:\u0007�\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0008).{2}(?-i:\u0000\u0008).{2,5}(?-i:\u000e\u0000\u0000@\u0000).{2,15}(?-i:\u0000\u0000\u0000\u0000\u0000\u0000\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000).*?(?-i:\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000)"
@@ -171401,8 +170256,7 @@ rules:
       to_server: true
   - name: "sid:2024336"
     description: "ET EXPLOIT Samba Arbitrary Module Loading Vulnerability (NT Create AndX .so) (CVE-2017-7494)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -171523,8 +170377,7 @@ rules:
       to_client: true
   - name: "sid:2024429"
     description: "ET MALWARE Win32/Parite.B Checkin 3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -171540,8 +170393,7 @@ rules:
       to_server: true
   - name: "sid:2024430"
     description: "ET EXPLOIT Possible ETERNALBLUE Exploit M3 MS17-010"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,4}(?-i:�SMB2\u0000\u0000\u0000\u0000\u0018\u0007�).{2,16}(?-i:\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0008��\u0000\u0008).{2,34}(?-i:\u000f\\\u000c\u0000\u0000\u0010\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000�\u0000\u0000\u0000\u0000\u0000\\\u000c\u0000B\u0000\u0000\u0010N\u0000\u0001\u0000\u000e\u0000\\\r\u0010\u0000)"
@@ -171835,8 +170687,7 @@ rules:
         flag: "ET.genericphish"
   - name: "sid:2024651"
     description: "ET MALWARE CobianRAT Checkin to CnC"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -171850,8 +170701,7 @@ rules:
       to_server: true
   - name: "sid:2024652"
     description: "ET MALWARE CobianRAT Receiving Commands From CnC"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -171865,8 +170715,7 @@ rules:
       to_client: true
   - name: "sid:2024653"
     description: "ET MALWARE CobianRAT Receiving Additional Commands From CnC"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -171880,8 +170729,7 @@ rules:
       to_client: true
   - name: "sid:2024654"
     description: "ET MALWARE CobianRAT Receiving Config Commands from CnC"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -171895,8 +170743,7 @@ rules:
       to_client: true
   - name: "sid:2024655"
     description: "ET MALWARE CobianRAT Screenshot Exfil to CnC"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -172754,8 +171601,7 @@ rules:
       to_server: true
   - name: "sid:2025644"
     description: "ET MALWARE Possible Metasploit Payload Common Construct Bind_API (from server)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -172766,8 +171612,7 @@ rules:
       to_client: true
   - name: "sid:2025649"
     description: "ET EXPLOIT Possible ETERNALBLUE Probe MS17-010 (MSF style)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,4}(?-i:�SMB%\u0000\u0000\u0000\u0000\u0018\u0001\\().{2,10}(?-i:\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000).*?(?-i:\\#\u0000\u0000\u0000\u0007\u0000\\\\PIPE\\\\\u0000)"
@@ -172777,8 +171622,7 @@ rules:
       to_server: true
   - name: "sid:2025650"
     description: "ET EXPLOIT ETERNALBLUE Probe Vulnerable System Response MS17-010"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,4}(?-i:�SMB%\u0005\u0002\u0000��\u0001).{3,10}(?-i:\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000).{3,8}(?-i:\u0000\u0000\u0000)"
@@ -173050,8 +171894,7 @@ rules:
       to_client: true
   - name: "sid:2025779"
     description: "ET EXPLOIT FTPShell client Stack Buffer Overflow"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:220\\ \").{400,}(?-i:�\\.E\"\\ )"
@@ -173061,8 +171904,7 @@ rules:
       to_client: true
   - name: "sid:2025887"
     description: "ET EXPLOIT Remote Command Execution via Android Debug Bridge"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -173076,8 +171918,7 @@ rules:
       to_client: true
   - name: "sid:2025888"
     description: "ET EXPLOIT Remote Command Execution via Android Debug Bridge 2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -173168,8 +172009,7 @@ rules:
       to_server: true
   - name: "sid:2025983"
     description: "ET EXPLOIT SMB Null Pointer Dereference PoC Inbound (CVE-2018-0833)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -173183,8 +172023,7 @@ rules:
       to_client: true
   - name: "sid:2025992"
     description: "ET EXPLOIT Possible ETERNALBLUE Probe MS17-010 (Generic Flags)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,4}(?-i:�SMB%\u0000\u0000\u0000\u0000).{5,10}(?-i:\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000).*?(?-i:\\#\u0000\u0000\u0000\u0007\u0000\\\\PIPE\\\\\u0000)"
@@ -173486,8 +172325,7 @@ rules:
       to_server: true
   - name: "sid:2026524"
     description: "ET MALWARE Win32/BlackCarat Response from CnC"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -173707,8 +172545,7 @@ rules:
       to_server: true
   - name: "sid:2026613"
     description: "ET MALWARE Mylobot Receiving XOR Encrypted Config (0xde)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -173859,8 +172696,7 @@ rules:
       to_client: true
   - name: "sid:2026732"
     description: "ET MALWARE Shamoon v3 32bit Propagating Internally via SMB"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,60}(?-i:\u0000\u0000\u0000\u0000\u0000\u0000).{2}(?-i:MZ).{0,4}(?-i:PE\u0000\u0000).{0,}(?-i:A�\u0014\u0002�E).{1,8}(?-i:2\u00140�\u0016;�r)"
@@ -173870,8 +172706,7 @@ rules:
       to_server: true
   - name: "sid:2026733"
     description: "ET MALWARE Shamoon v3 64bit Propagating Internally via SMB"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0000\u0000\u0000\u0000).{2}(?-i:MZ).{0,4}(?-i:PE\u0000\u0000).{0,}(?-i:H��B\u000f�).{2}(?-i:2E).{1,4}(?-i:A�A�)"
@@ -174133,8 +172968,7 @@ rules:
       to_client: true
   - name: "sid:2026879"
     description: "ET INFO Possible winexe over SMB - Possible Lateral Movement"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,4}(?-i:�SMB).*?(?i:\\\\\u0000a\u0000h\u0000e\u0000x\u0000e\u0000c\u0000\u0000\u0000)"
@@ -174198,8 +173032,7 @@ rules:
       to_server: true
   - name: "sid:2026917"
     description: "ET EXPLOIT Possible MicroLogix 1100 PCCC DoS Condition (CVE-2017-7924)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -174556,8 +173389,7 @@ rules:
       to_client: true
   - name: "sid:2027101"
     description: "ET MALWARE Observed Malicious SSL Cert (Gootkit CnC)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�\u001cws\\.diminishedvalueoregon\\.com).*?(?-i:0E:1F:E3:45:FC:89)"
@@ -174837,8 +173669,7 @@ rules:
       to_client: true
   - name: "sid:2027364"
     description: "ET MALWARE BlackTech Plead Encrypted Payload Inbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:�\u0000\u0013�3\u0000�\u0006\u0019)"
@@ -174848,8 +173679,7 @@ rules:
       to_client: true
   - name: "sid:2027369"
     description: "ET EXPLOIT [NCC GROUP] Possible Bluekeep Inbound RDP Exploitation Attempt (CVE-2019-0708)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -175382,8 +174212,7 @@ rules:
       to_client: true
   - name: "sid:2027843"
     description: "ET MALWARE ELF/Emptiness v2 XOR UDP Flood Command Inbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -175394,8 +174223,7 @@ rules:
       to_client: true
   - name: "sid:2027844"
     description: "ET MALWARE ELF/Emptiness v2 XOR DNS Flood Command Inbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -175406,8 +174234,7 @@ rules:
       to_client: true
   - name: "sid:2027845"
     description: "ET MALWARE ELF/Emptiness v2 XOR HTTP Flood Command Inbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -175418,8 +174245,7 @@ rules:
       to_client: true
   - name: "sid:2027846"
     description: "ET MALWARE ELF/Emptiness v2 XOR Exec Command Inbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -175430,8 +174256,7 @@ rules:
       to_client: true
   - name: "sid:2027847"
     description: "ET MALWARE ELF/Emptiness v2 XOR Update Command Inbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -175676,8 +174501,7 @@ rules:
       to_client: true
   - name: "sid:2028863"
     description: "ET MALWARE APT 41 LOWKEY Backdoor - Initalisation Bytes Received from CnC"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -175691,8 +174515,7 @@ rules:
       to_client: true
   - name: "sid:2028876"
     description: "ET MALWARE Steganographic Encoded WAV File Inbound via HTTP M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:RIFF).{4}(?-i:WAVE).{6,32}(?-i:\\\u000b�\u0006S�:)"
@@ -175702,8 +174525,7 @@ rules:
       to_client: true
   - name: "sid:2028877"
     description: "ET MALWARE Steganographic Encoded WAV File Inbound via HTTP M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:RIFF).{4}(?-i:WAVE).{6,32}(?-i:\\\\�\u0013o�R)"
@@ -176279,8 +175101,7 @@ rules:
       to_client: true
   - name: "sid:2029420"
     description: "ET MALWARE Possible APT40/Dadstache Stage 2 Payload Beacon"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:Content\\-Disposition:\\ form\\-data;\\ name=\"file\";\\ filename=\").{0,}(?-i:\\.png\"\\\r\\\nContent\\-Type:\\ video/JPEG\\\r\\\n\\\r\\\n�PNG)"
@@ -176836,8 +175657,7 @@ rules:
       to_server: true
   - name: "sid:2029996"
     description: "ET MALWARE NanoCore RAT CnC 27"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -177153,8 +175973,7 @@ rules:
       to_client: true
   - name: "sid:2030533"
     description: "ET EXPLOIT Possible Windows DNS Integer Overflow Attempt M1 (CVE-2020-1350)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -177594,8 +176413,7 @@ rules:
       to_server: true
   - name: "sid:2000332"
     description: "ET P2P ed2k request part"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -177609,8 +176427,7 @@ rules:
       to_server: true
   - name: "sid:2000333"
     description: "ET P2P ed2k file request answer"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -180939,8 +179756,7 @@ rules:
       to_client: true
   - name: "sid:2033239"
     description: "ET MALWARE Mirai pTea Variant - Bot Upload Command Outbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -180953,8 +179769,7 @@ rules:
       to_client: true
   - name: "sid:2033244"
     description: "ET MALWARE Mirai pTea Variant - Bot Upload Command Inbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -182296,8 +181111,7 @@ rules:
       to_server: true
   - name: "sid:2042989"
     description: "ET MALWARE Win32/RisePro CnC Server Response M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:M\u0014EC��SEE\u0014\\\u000cBDCS\u001a)"
@@ -182347,8 +181161,7 @@ rules:
       to_server: true
   - name: "sid:2043277"
     description: "ET MALWARE Win32/Nitol.A CnC Checkin M3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -182581,8 +181394,7 @@ rules:
       to_server: true
   - name: "sid:2100288"
     description: "GPL POP3 x86 Linux overflow"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -182596,8 +181408,7 @@ rules:
       to_server: true
   - name: "sid:2100289"
     description: "GPL POP3 x86 SCO overflow"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -182611,8 +181422,7 @@ rules:
       to_server: true
   - name: "sid:2100293"
     description: "GPL IMAP Overflow Attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -182810,8 +181620,7 @@ rules:
       to_client: true
   - name: "sid:2100529"
     description: "GPL NETBIOS DOS RFPoison"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -182878,8 +181687,7 @@ rules:
       to_server: true
   - name: "sid:2100569"
     description: "GPL RPC snmpXdmi overflow attempt TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -182900,8 +181708,7 @@ rules:
       to_server: true
   - name: "sid:2100591"
     description: "GPL RPC portmap ypupdated request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -182915,8 +181722,7 @@ rules:
       to_server: true
   - name: "sid:2100593"
     description: "GPL RPC portmap snmpXdmi request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -182930,8 +181736,7 @@ rules:
       to_server: true
   - name: "sid:2100595"
     description: "GPL RPC portmap espd request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -182945,8 +181750,7 @@ rules:
       to_server: true
   - name: "sid:2100598"
     description: "GPL RPC portmap listing TCP 111"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -183394,8 +182198,7 @@ rules:
       to_server: true
   - name: "sid:2100691"
     description: "GPL SHELLCODE MSSQL shellcode attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -183409,8 +182212,7 @@ rules:
       to_server: true
   - name: "sid:2100692"
     description: "GPL SQL shellcode attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -183424,8 +182226,7 @@ rules:
       to_server: true
   - name: "sid:2100693"
     description: "GPL SQL MSSQL shellcode attempt 2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -183439,8 +182240,7 @@ rules:
       to_server: true
   - name: "sid:2100694"
     description: "GPL SQL shellcode attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -183839,8 +182639,7 @@ rules:
       to_server: true
   - name: "sid:2101262"
     description: "GPL RPC portmap admind request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -183854,8 +182653,7 @@ rules:
       to_server: true
   - name: "sid:2101263"
     description: "GPL RPC portmap amountd request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -183869,8 +182667,7 @@ rules:
       to_server: true
   - name: "sid:2101264"
     description: "GPL RPC portmap bootparam request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -183884,8 +182681,7 @@ rules:
       to_server: true
   - name: "sid:2101265"
     description: "GPL RPC portmap cmsd request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -183899,8 +182695,7 @@ rules:
       to_server: true
   - name: "sid:2101267"
     description: "GPL RPC portmap nisd request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -183914,8 +182709,7 @@ rules:
       to_server: true
   - name: "sid:2101268"
     description: "GPL RPC portmap pcnfsd request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -183929,8 +182723,7 @@ rules:
       to_server: true
   - name: "sid:2101269"
     description: "GPL RPC portmap rexd request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -183944,8 +182737,7 @@ rules:
       to_server: true
   - name: "sid:2101270"
     description: "GPL RPC portmap rstatd request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -183959,8 +182751,7 @@ rules:
       to_server: true
   - name: "sid:2101271"
     description: "GPL RPC portmap rusers request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -183974,8 +182765,7 @@ rules:
       to_server: true
   - name: "sid:2101272"
     description: "GPL RPC portmap sadmind request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -183989,8 +182779,7 @@ rules:
       to_server: true
   - name: "sid:2101273"
     description: "GPL RPC portmap selection_svc request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -184004,8 +182793,7 @@ rules:
       to_server: true
   - name: "sid:2101274"
     description: "GPL RPC portmap ttdbserv request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -184019,8 +182807,7 @@ rules:
       to_server: true
   - name: "sid:2101275"
     description: "GPL RPC portmap yppasswd request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -184034,8 +182821,7 @@ rules:
       to_server: true
   - name: "sid:2101276"
     description: "GPL RPC portmap ypserv request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -184382,8 +183168,7 @@ rules:
       to_server: true
   - name: "sid:2101733"
     description: "GPL RPC portmap rwalld request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -184407,8 +183192,7 @@ rules:
       to_server: true
   - name: "sid:2101747"
     description: "GPL RPC portmap cachefsd request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -184436,8 +183220,7 @@ rules:
       to_server: true
   - name: "sid:2101775"
     description: "GPL SQL MYSQL root login attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -184534,8 +183317,7 @@ rules:
       to_server: true
   - name: "sid:2101908"
     description: "GPL RPC CMSD TCP CMSD_CREATE buffer overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -184556,8 +183338,7 @@ rules:
       to_server: true
   - name: "sid:2101909"
     description: "GPL RPC CMSD TCP CMSD_INSERT buffer overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -184578,8 +183359,7 @@ rules:
       to_server: true
   - name: "sid:2101912"
     description: "GPL RPC sadmind TCP NETMGT_PROC_SERVICE CLIENT_DOMAIN overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -184600,8 +183380,7 @@ rules:
       to_server: true
   - name: "sid:2101914"
     description: "GPL RPC STATD TCP stat mon_name format string exploit attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -184622,8 +183401,7 @@ rules:
       to_server: true
   - name: "sid:2101916"
     description: "GPL RPC STATD TCP monitor mon_name format string exploit attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -184680,8 +183458,7 @@ rules:
       to_server: true
   - name: "sid:2101922"
     description: "GPL RPC portmap proxy attempt TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -184771,8 +183548,7 @@ rules:
       to_server: true
   - name: "sid:2101949"
     description: "GPL RPC portmap SET attempt TCP 111"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -184786,8 +183562,7 @@ rules:
       to_server: true
   - name: "sid:2101960"
     description: "GPL RPC portmap NFS request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -184801,8 +183576,7 @@ rules:
       to_server: true
   - name: "sid:2101962"
     description: "GPL RPC portmap RQUOTA request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -184816,8 +183590,7 @@ rules:
       to_server: true
   - name: "sid:2101965"
     description: "GPL RPC tooltalk TCP overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -184929,8 +183702,7 @@ rules:
       to_server: true
   - name: "sid:2102006"
     description: "GPL RPC portmap kcms_server request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -185028,8 +183800,7 @@ rules:
       to_client: true
   - name: "sid:2102014"
     description: "GPL RPC portmap UNSET attempt TCP 111"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -185043,8 +183814,7 @@ rules:
       to_server: true
   - name: "sid:2102016"
     description: "GPL RPC portmap status request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -185058,8 +183828,7 @@ rules:
       to_server: true
   - name: "sid:2102036"
     description: "GPL RPC portmap network-status-monitor request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -185107,8 +183876,7 @@ rules:
       to_server: true
   - name: "sid:2102082"
     description: "GPL RPC portmap rpc.xfsmd request TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -185122,8 +183890,7 @@ rules:
       to_server: true
   - name: "sid:2102093"
     description: "GPL RPC portmap proxy integer overflow attempt TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -185147,8 +183914,7 @@ rules:
       to_server: true
   - name: "sid:2102103"
     description: "GPL NETBIOS SMB trans2open buffer overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -185224,8 +183990,7 @@ rules:
       to_server: true
   - name: "sid:2102176"
     description: "GPL NETBIOS SMB startup folder access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -185239,8 +184004,7 @@ rules:
       to_server: true
   - name: "sid:2102177"
     description: "GPL NETBIOS SMB startup folder unicode access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -185278,8 +184042,7 @@ rules:
       to_server: true
   - name: "sid:2102184"
     description: "GPL RPC mountd TCP mount path overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -185324,8 +184087,7 @@ rules:
       to_server: true
   - name: "sid:2102191"
     description: "GPL NETBIOS SMB DCERPC invalid bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -185349,8 +184111,7 @@ rules:
       to_server: true
   - name: "sid:2102251"
     description: "GPL NETBIOS DCERPC Remote Activation bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -185374,8 +184135,7 @@ rules:
       to_server: true
   - name: "sid:2102252"
     description: "GPL NETBIOS SMB-DS DCERPC Remote Activation bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -185399,8 +184159,7 @@ rules:
       to_server: true
   - name: "sid:2102255"
     description: "GPL RPC sadmind query with root credentials attempt TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -185411,8 +184170,7 @@ rules:
       to_server: true
   - name: "sid:2102258"
     description: "GPL NETBIOS SMB-DS DCERPC Messenger Service buffer overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -185473,8 +184231,7 @@ rules:
       to_client: true
   - name: "sid:2102308"
     description: "GPL NETBIOS SMB DCERPC Workstation Service unicode bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -185507,8 +184264,7 @@ rules:
       to_server: true
   - name: "sid:2102309"
     description: "GPL NETBIOS SMB DCERPC Workstation Service bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -185541,8 +184297,7 @@ rules:
       to_server: true
   - name: "sid:2102310"
     description: "GPL NETBIOS SMB-DS DCERPC Workstation Service unicode bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -185575,8 +184330,7 @@ rules:
       to_server: true
   - name: "sid:2102311"
     description: "GPL NETBIOS SMB-DS DCERPC Workstation Service bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -185609,8 +184363,7 @@ rules:
       to_server: true
   - name: "sid:2102315"
     description: "GPL NETBIOS DCERPC Workstation Service direct service bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -185676,8 +184429,7 @@ rules:
       to_server: true
   - name: "sid:2102384"
     description: "GPL NETBIOS SMB NTLMSSP invalid mechlistMIC attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -185691,8 +184443,7 @@ rules:
       to_server: true
   - name: "sid:2102385"
     description: "GPL NETBIOS SMB-DS DCERPC NTLMSSP invalid mechlistMIC attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -185758,8 +184509,7 @@ rules:
       to_server: true
   - name: "sid:2102401"
     description: "GPL NETBIOS SMB Session Setup AndX request username overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -185801,8 +184551,7 @@ rules:
       to_server: true
   - name: "sid:2102402"
     description: "GPL NETBIOS SMB-DS Session Setup AndX request username overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -185948,8 +184697,7 @@ rules:
       to_server: true
   - name: "sid:2102458"
     description: "GPL CHAT Yahoo IM successful chat join"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -186005,8 +184753,7 @@ rules:
       to_client: true
   - name: "sid:2102511"
     description: "GPL NETBIOS SMB DCERPC LSASS DsRolerUpgradeDownlevelServer exploit attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -187903,8 +186650,7 @@ rules:
       to_server: true
   - name: "sid:2032823"
     description: "ET MALWARE MICROPSIA Screenshot Upload M3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:Content\\-Disposition:\\ form\\-data;\\ name=\"vcqmxylcv\").*?(?-i:\\\r\\\n\\\r\\\n����).{0,40}(?-i:JFIF)"
@@ -187974,8 +186720,7 @@ rules:
       to_client: true
   - name: "sid:2033448"
     description: "ET EXPLOIT Possible CloudMe Sync Stack-based Buffer Overflow Inbound (CVE-2018-6892)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -188383,8 +187128,7 @@ rules:
       to_client: true
   - name: "sid:2042974"
     description: "ET MALWARE Charming Kitten APT Related DNS Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -188426,8 +187170,7 @@ rules:
       to_server: true
   - name: "sid:2044067"
     description: "ET MALWARE Win32/Kumquat Loader Activity (Subscribe)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -188455,8 +187198,7 @@ rules:
         flag: "ET.kumquat"
   - name: "sid:2044118"
     description: "ET EXPLOIT Possible ImageMagick (7.1.0-49) DOS PNG Upload Attempt (CVE-2022-44267)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:�PNG).{0,256}(?-i:profile\u0000\\-)"
@@ -188466,8 +187208,7 @@ rules:
       to_server: true
   - name: "sid:2044119"
     description: "ET EXPLOIT Possible ImageMagick (7.1.0-49) DOS PNG Observed Inbound (CVE-2022-44267)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�PNG).{0,256}(?-i:profile\u0000\\-)"
@@ -188477,8 +187218,7 @@ rules:
       to_client: true
   - name: "sid:2044120"
     description: "ET EXPLOIT Possible ImageMagick (7.1.0-49) Arbitrary Remote Leak PNG Upload Attempt (CVE-2022-44268)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:�PNG).{0,256}(?-i:profile\u0000/)"
@@ -188821,8 +187561,7 @@ rules:
       to_server: true
   - name: "sid:2102923"
     description: "GPL NETBIOS SMB repeated logon failure"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -188836,8 +187575,7 @@ rules:
       to_client: true
   - name: "sid:2102924"
     description: "GPL NETBIOS SMB-DS repeated logon failure"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -189864,8 +188602,7 @@ rules:
       to_server: true
   - name: "sid:2012298"
     description: "ET ADWARE_PUP User-Agent (0xa10xa1HttpClient)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?i:��HttpClient)"
@@ -189976,8 +188713,7 @@ rules:
       to_server: true
   - name: "sid:2051603"
     description: "ET MALWARE Win32/Unknown InfoStealer CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -190669,8 +189405,7 @@ rules:
       to_client: true
   - name: "sid:2051641"
     description: "ET MALWARE Rust HackTool CnC Activity (Outbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -193788,8 +192523,7 @@ rules:
       to_client: true
   - name: "sid:2019169"
     description: "ET MALWARE Tinba Server Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,4}(?-i:d�ܤ)"
@@ -194732,8 +193466,7 @@ rules:
       to_client: true
   - name: "sid:2021382"
     description: "ET MALWARE Zberp/ZeusVM receiving config via image file (steganography)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:��\\?\u0010\u0000\u0000).*?(?-i:^[^\\x00]+(\\xff\\xd9)?$)"
@@ -194756,8 +193489,7 @@ rules:
         flag: "ET.Zberp"
   - name: "sid:2021383"
     description: "ET MALWARE Zberp/ZeusVM receiving config via image file (steganography) 2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:0103F\u0000).{0,2}(?-i:��).*?(?-i:^0103F\\x00[^\\x00]+(\\xff\\xd9)?$)"
@@ -195080,8 +193812,7 @@ rules:
       to_client: true
   - name: "sid:2021758"
     description: "ET EXPLOIT Possible Android Stagefright MP4 CVE-2015-1538 - ROP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,13}(?-i:\u0000\u0000\u0000\u0018ftypmp4).*?(?-i:�\\*\u0000��8\u0000�).{4,20}(?-i:\u0000\u0010\u0000\u0000\u0007\u0000\u0000\u0000\u0003�\u0000�\u0004�\u0000�D\u0011\u0000�)"
@@ -195091,8 +193822,7 @@ rules:
       to_client: true
   - name: "sid:2021759"
     description: "ET EXPLOIT Possible Android Stagefright MP4 CVE-2015-1538 - STSC"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:stsc\u0000\u0000\u0000\u0000�\u0000\u0000\u0003).*?(?i:^(?P<addr1>.{4})(?P<addr2>.{4})(?P=addr2)(?P=addr1))"
@@ -195390,8 +194120,7 @@ rules:
       to_client: true
   - name: "sid:2022484"
     description: "ET EXPLOIT_KIT RIG encrypted payload M1 Feb 02 2016"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,8}(?-i:;\\-�K@wwA)"
@@ -195511,8 +194240,7 @@ rules:
       to_client: true
   - name: "sid:2022890"
     description: "ET WEB_CLIENT Google Chrome Pdfium JPEG2000 Heap Overflow"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:stream).{0,}(?-i:\u0000\u0000\u0000\\\u000cjP\\ \\ \\\r\\\n�\\\n).{0,}(?-i:\u0000\u0000\u0000\u0000jp2c�O).{0,200}(?-i:�Q).{3,36}(?-i:\u0000\u0000�).*?(?-i:^[\\x52\\x5c\\x64\\x65\\x90\\x93])"
@@ -195544,8 +194272,7 @@ rules:
         flag: "ET.pdf.in.http"
   - name: "sid:2022916"
     description: "ET EXPLOIT_KIT RIG EK Payload Jun 26 2016"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,9}(?-i:,\\-�K@DwA)"
@@ -195555,8 +194282,7 @@ rules:
       to_client: true
   - name: "sid:2022923"
     description: "ET EXPLOIT Possible CVE-2016-2209 Symantec PowerPoint Parsing Buffer Overflow M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�j���,�\u0016��6\\{A\\.\u007fK�'\u0013��\u001f�\\+�\\+:�\\\tw��\\)\u0000\u0000�\u000f�\u0003\u0000\u0000).{8,913}(?-i:\u0000\u0000�\u000f\u0016\u0001\u0000\u0000)"
@@ -195566,8 +194292,7 @@ rules:
       to_client: true
   - name: "sid:2022924"
     description: "ET EXPLOIT Possible CVE-2016-2209 Symantec PowerPoint Parsing Buffer Overflow M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�j���,�\u0016��6\\{A\\.\u007fK�'\u0013��\u001f�\\+�\\+:�\\\tw��\\)\u0000\u0000�\u000f�\u0003\u0000\u0000).{8,937}(?-i:\u0000\u0000�\u000f\\.\u0001\u0000\u0000)"
@@ -195597,8 +194322,7 @@ rules:
       to_client: true
   - name: "sid:2022949"
     description: "ET EXPLOIT_KIT RIG EK Payload Jul 05 2016"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,8}(?-i:;\\-�K@wwA)"
@@ -196214,8 +194938,7 @@ rules:
       to_client: true
   - name: "sid:2024053"
     description: "ET EXPLOIT_KIT Terror EK Payload Download M1 Mar 14 2017"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,8}(?-i:\\.�\u0008���\\{l)"
@@ -196225,8 +194948,7 @@ rules:
       to_client: true
   - name: "sid:2024054"
     description: "ET EXPLOIT_KIT Terror EK Payload Download M2 Mar 14 2017"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,8}(?-i:\\^Z���1\\{T)"
@@ -196616,8 +195338,7 @@ rules:
       to_client: true
   - name: "sid:2024507"
     description: "ET EXPLOIT_KIT RIG encrypted payload M1 Aug 01 2017"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,8}(?-i:s\\)����\u000et)"
@@ -196912,8 +195633,7 @@ rules:
       to_client: true
   - name: "sid:2024691"
     description: "ET EXPLOIT_KIT RIG EK encrypted payload Sept 11 (1)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,8}(?-i:����6�\\]�)"
@@ -197276,8 +195996,7 @@ rules:
       to_client: true
   - name: "sid:2025070"
     description: "ET MALWARE Win32/Atraps Receiving Config via Image File (steganography)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:��\\#).{0,}(?-i:\\$:1:\\$).*?(?-i:^[A-Za-z0-9+/=]+\\x24\\x3a\\d+\\x3a\\x24$)"
@@ -197370,8 +196089,7 @@ rules:
       to_client: true
   - name: "sid:2025195"
     description: "ET EXPLOIT Possible MeltDown PoC Download In Progress"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:WSAPAQ).{50,53}(?-i:\u000f��).{12,15}(?-i:\u000f�).{25,45}(?-i:\u000f��\u000f1).{12,17}(?-i:\u000f��\u000f1).*?(?-i:^[\\x30-\\x3f\\x7D])"
@@ -197384,8 +196102,7 @@ rules:
         flag: "ET.http.binary"
   - name: "sid:2025196"
     description: "ET EXPLOIT Possible Spectre PoC Download In Progress"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�\u0003\u0000\u0000).{9,17}(?-i:H\u000f�).{10,41}(?-i:H\u000f�=).{22,64}(?-i:H�).{9,50}(?-i:\u000f\u0001�).{9,30}(?-i:\u000f\u0001�).*?(?-i:^[\\x30-\\x3f\\x7D])"
@@ -198578,8 +197295,7 @@ rules:
       to_client: true
   - name: "sid:2025437"
     description: "ET EXPLOIT_KIT [PTsecurity] Grandsoft EK Payload"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:�\u0008����\"�fXJ�\\.)"
@@ -199924,8 +198640,7 @@ rules:
       to_client: true
   - name: "sid:2027085"
     description: "ET MALWARE Possible Inbound PowerShell via Invoke-PSImage Stego"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,4}(?-i:�PNG).{0,75}(?-i:c2FsIGEgTmV3LU9iamVjdDt)"
@@ -200091,8 +198806,7 @@ rules:
       to_client: true
   - name: "sid:2029336"
     description: "ET MALWARE Mimikatz x86 Mimidrv.sys Download Over HTTP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,2}(?-i:MZ).{0,}(?-i:�\u0000\u0000\u0000\\$\u0002\u0000\u0000@\u0000\u0000\u0000).{0,16}(?-i:�\u0000\u0000\u0000l\u0002\u0000\u0000@\u0000\u0000\u0000)"
@@ -200102,8 +198816,7 @@ rules:
       to_client: true
   - name: "sid:2029337"
     description: "ET MALWARE Mimikatz x64 Mimidrv.sys Download Over HTTP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,2}(?-i:MZ).{0,}(?-i:�\u0001\u0000\u0000<\u0004\u0000\u0000@\u0000\u0000\u0000).{0,16}(?-i:�\u0002\u0000\u0000�\u0002\u0000\u0000@\u0000\u0000\u0000)"
@@ -200263,8 +198976,7 @@ rules:
       to_client: true
   - name: "sid:2030110"
     description: "ET MALWARE nspps Backdoor - Task Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:404).*?(?-i:b7U\u0014�Y�\\(�4)"
@@ -200274,8 +198986,7 @@ rules:
       to_client: true
   - name: "sid:2030365"
     description: "ET MALWARE HTTPCore CnC Tasking File"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:�PNW\\\r\\\n\u001a\\\n<<<<)"
@@ -201011,8 +199722,7 @@ rules:
       to_client: true
   - name: "sid:2035042"
     description: "ET MALWARE Emotet Post Drop C2 Comms"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:P!c\u0017J�i��wŝ��\u0014\u001e�/�)"
@@ -201145,8 +199855,7 @@ rules:
         flag: "et.exploitkitlanding"
   - name: "sid:2048508"
     description: "ET INFO LNK File Downloaded via HTTP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,4}(?-i:\u0001\u0014\u0002\u0000\u0000\u0000\u0000\u0000�\u0000\u0000\u0000\u0000\u0000\u0000F)"
@@ -201156,8 +199865,7 @@ rules:
       to_client: true
   - name: "sid:2006395"
     description: "ET MALWARE Socks666 Connection Initial Packet"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -201204,8 +199912,7 @@ rules:
     private: true
   - name: "sid:2102479"
     description: "GPL NETBIOS SMB-DS winreg unicode bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -201234,8 +199941,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2102478"
     description: "GPL NETBIOS SMB-DS winreg bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -201264,8 +199970,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2102477"
     description: "GPL NETBIOS SMB-DS winreg unicode create tree attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -201294,8 +199999,7 @@ rules:
         flag: "smb.tree.create.winreg"
   - name: "sid:2102476"
     description: "GPL NETBIOS SMB-DS winreg create tree attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -201324,8 +200028,7 @@ rules:
         flag: "smb.tree.create.winreg"
   - name: "sid:2103377"
     description: "GPL NETBIOS SMB IActivation bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -201362,8 +200065,7 @@ rules:
     private: true
   - name: "sid:2103378"
     description: "GPL NETBIOS SMB IActivation little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -201400,8 +200102,7 @@ rules:
     private: true
   - name: "sid:2103379"
     description: "GPL NETBIOS SMB IActivation unicode bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -201438,8 +200139,7 @@ rules:
     private: true
   - name: "sid:2103380"
     description: "GPL NETBIOS SMB IActivation unicode little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -201476,8 +200176,7 @@ rules:
     private: true
   - name: "sid:2103393"
     description: "GPL NETBIOS SMB ISystemActivator bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -201514,8 +200213,7 @@ rules:
     private: true
   - name: "sid:2103396"
     description: "GPL NETBIOS SMB ISystemActivator unicode little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -201552,8 +200250,7 @@ rules:
     private: true
   - name: "sid:2103240"
     description: "GPL NETBIOS SMB irot bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -201590,8 +200287,7 @@ rules:
     private: true
   - name: "sid:2103241"
     description: "GPL NETBIOS SMB irot little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -201628,8 +200324,7 @@ rules:
     private: true
   - name: "sid:2103098"
     description: "GPL NETBIOS SMB llsrpc bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -201665,8 +200360,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103099"
     description: "GPL NETBIOS SMB llsrpc little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -201702,8 +200396,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103160"
     description: "GPL NETBIOS SMB msqueue bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -201740,8 +200433,7 @@ rules:
     private: true
   - name: "sid:2103161"
     description: "GPL NETBIOS SMB msqueue little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -201778,8 +200470,7 @@ rules:
     private: true
   - name: "sid:2102932"
     description: "GPL NETBIOS SMB nddeapi bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -201808,8 +200499,7 @@ rules:
         flag: "smb.tree.bind.nddeapi"
   - name: "sid:2103162"
     description: "GPL NETBIOS SMB msqueue unicode bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -201846,8 +200536,7 @@ rules:
     private: true
   - name: "sid:2103163"
     description: "GPL NETBIOS SMB msqueue unicode little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -201884,8 +200573,7 @@ rules:
     private: true
   - name: "sid:2102928"
     description: "GPL NETBIOS SMB nddeapi create tree attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -201914,8 +200602,7 @@ rules:
         flag: "smb.tree.create.nddeapi"
   - name: "sid:2102933"
     description: "GPL NETBIOS SMB nddeapi unicode bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -201944,8 +200631,7 @@ rules:
         flag: "smb.tree.bind.nddeapi"
   - name: "sid:2102929"
     description: "GPL NETBIOS SMB nddeapi unicode create tree attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -201974,8 +200660,7 @@ rules:
         flag: "smb.tree.create.nddeapi"
   - name: "sid:2103202"
     description: "GPL NETBIOS SMB winreg bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202012,8 +200697,7 @@ rules:
     private: true
   - name: "sid:2102940"
     description: "GPL NETBIOS SMB winreg bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202042,8 +200726,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2102174"
     description: "GPL NETBIOS SMB winreg create tree attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202072,8 +200755,7 @@ rules:
         flag: "smb.tree.create.winreg"
   - name: "sid:2103203"
     description: "GPL NETBIOS SMB winreg little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202110,8 +200792,7 @@ rules:
     private: true
   - name: "sid:2103204"
     description: "GPL NETBIOS SMB winreg unicode bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202148,8 +200829,7 @@ rules:
     private: true
   - name: "sid:2102941"
     description: "GPL NETBIOS SMB winreg unicode bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202178,8 +200858,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2102175"
     description: "GPL NETBIOS SMB winreg unicode create tree attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202208,8 +200887,7 @@ rules:
         flag: "smb.tree.create.winreg"
   - name: "sid:2103205"
     description: "GPL NETBIOS SMB winreg unicode little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202246,8 +200924,7 @@ rules:
     private: true
   - name: "sid:2103385"
     description: "GPL NETBIOS SMB-DS IActivation bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202284,8 +200961,7 @@ rules:
     private: true
   - name: "sid:2103386"
     description: "GPL NETBIOS SMB-DS IActivation little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202322,8 +200998,7 @@ rules:
     private: true
   - name: "sid:2103387"
     description: "GPL NETBIOS SMB-DS IActivation unicode bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202360,8 +201035,7 @@ rules:
     private: true
   - name: "sid:2103388"
     description: "GPL NETBIOS SMB-DS IActivation unicode little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202398,8 +201072,7 @@ rules:
     private: true
   - name: "sid:2102465"
     description: "GPL NETBIOS SMB-DS IPC$ share access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202426,8 +201099,7 @@ rules:
         flag: "smb.tree.connect.ipc"
   - name: "sid:2102466"
     description: "GPL NETBIOS SMB-DS IPC$ unicode share access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202454,8 +201126,7 @@ rules:
         flag: "smb.tree.connect.ipc"
   - name: "sid:2103401"
     description: "GPL NETBIOS SMB-DS ISystemActivator bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202492,8 +201163,7 @@ rules:
     private: true
   - name: "sid:2103402"
     description: "GPL NETBIOS SMB-DS ISystemActivator little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202530,8 +201200,7 @@ rules:
     private: true
   - name: "sid:2103403"
     description: "GPL NETBIOS SMB-DS ISystemActivator unicode bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202568,8 +201237,7 @@ rules:
     private: true
   - name: "sid:2103404"
     description: "GPL NETBIOS SMB-DS ISystemActivator unicode little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202606,8 +201274,7 @@ rules:
     private: true
   - name: "sid:2103248"
     description: "GPL NETBIOS SMB-DS irot bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202644,8 +201311,7 @@ rules:
     private: true
   - name: "sid:2103249"
     description: "GPL NETBIOS SMB-DS irot little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202682,8 +201348,7 @@ rules:
     private: true
   - name: "sid:2103250"
     description: "GPL NETBIOS SMB-DS irot unicode bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202720,8 +201385,7 @@ rules:
     private: true
   - name: "sid:2103251"
     description: "GPL NETBIOS SMB-DS irot unicode little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202758,8 +201422,7 @@ rules:
     private: true
   - name: "sid:2103106"
     description: "GPL NETBIOS SMB-DS llsrpc bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202795,8 +201458,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103107"
     description: "GPL NETBIOS SMB-DS llsrpc little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202832,8 +201494,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103108"
     description: "GPL NETBIOS SMB-DS llsrpc unicode bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202869,8 +201530,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103109"
     description: "GPL NETBIOS SMB-DS llsrpc unicode little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202906,8 +201566,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103170"
     description: "GPL NETBIOS SMB-DS msqueue unicode bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202944,8 +201603,7 @@ rules:
     private: true
   - name: "sid:2103171"
     description: "GPL NETBIOS SMB-DS msqueue unicode little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -202982,8 +201640,7 @@ rules:
     private: true
   - name: "sid:2102934"
     description: "GPL NETBIOS SMB-DS nddeapi bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203012,8 +201669,7 @@ rules:
         flag: "smb.tree.bind.nddeapi"
   - name: "sid:2102930"
     description: "GPL NETBIOS SMB-DS nddeapi create tree attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203042,8 +201698,7 @@ rules:
         flag: "smb.tree.create.nddeapi"
   - name: "sid:2102935"
     description: "GPL NETBIOS SMB-DS nddeapi unicode bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203072,8 +201727,7 @@ rules:
         flag: "smb.tree.bind.nddeapi"
   - name: "sid:2102931"
     description: "GPL NETBIOS SMB-DS nddeapi unicode create tree attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203102,8 +201756,7 @@ rules:
         flag: "smb.tree.create.nddeapi"
   - name: "sid:2103210"
     description: "GPL NETBIOS SMB-DS winreg bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203140,8 +201793,7 @@ rules:
     private: true
   - name: "sid:2103211"
     description: "GPL NETBIOS SMB-DS winreg little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203178,8 +201830,7 @@ rules:
     private: true
   - name: "sid:2103212"
     description: "GPL NETBIOS SMB-DS winreg unicode bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203216,8 +201867,7 @@ rules:
     private: true
   - name: "sid:2103213"
     description: "GPL NETBIOS SMB-DS winreg unicode little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203254,8 +201904,7 @@ rules:
     private: true
   - name: "sid:2103394"
     description: "GPL NETBIOS SMB ISystemActivator little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203292,8 +201941,7 @@ rules:
     private: true
   - name: "sid:2103395"
     description: "GPL NETBIOS SMB ISystemActivator unicode bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203330,8 +201978,7 @@ rules:
     private: true
   - name: "sid:2103242"
     description: "GPL NETBIOS SMB irot unicode bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203368,8 +202015,7 @@ rules:
     private: true
   - name: "sid:2103243"
     description: "GPL NETBIOS SMB irot unicode little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203406,8 +202052,7 @@ rules:
     private: true
   - name: "sid:2103100"
     description: "GPL NETBIOS SMB llsrpc unicode bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203443,8 +202088,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103101"
     description: "GPL NETBIOS SMB llsrpc unicode little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203480,8 +202124,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103168"
     description: "GPL NETBIOS SMB-DS msqueue bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203518,8 +202161,7 @@ rules:
     private: true
   - name: "sid:2103169"
     description: "GPL NETBIOS SMB-DS msqueue little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203556,8 +202198,7 @@ rules:
     private: true
   - name: "sid:2100538"
     description: "GPL NETBIOS SMB IPC$ unicode share access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203584,8 +202225,7 @@ rules:
         flag: "smb.tree.connect.ipc"
   - name: "sid:2100537"
     description: "GPL NETBIOS SMB IPC$ share access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203612,8 +202252,7 @@ rules:
         flag: "smb.tree.connect.ipc"
   - name: "sid:2103275"
     description: "GPL NETBIOS DCERPC IActivation bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203640,8 +202279,7 @@ rules:
         flag: "dce.isystemactivator.bind"
   - name: "sid:2103276"
     description: "GPL NETBIOS DCERPC IActivation little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203668,8 +202306,7 @@ rules:
         flag: "dce.isystemactivator.bind"
   - name: "sid:2103236"
     description: "GPL NETBIOS DCERPC irot bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203697,8 +202334,7 @@ rules:
     private: true
   - name: "sid:2103237"
     description: "GPL NETBIOS DCERPC irot little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203726,8 +202362,7 @@ rules:
     private: true
   - name: "sid:2103381"
     description: "GPL NETBIOS SMB IActivation andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203764,8 +202399,7 @@ rules:
     private: true
   - name: "sid:2103382"
     description: "GPL NETBIOS SMB IActivation little endian andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203802,8 +202436,7 @@ rules:
     private: true
   - name: "sid:2103383"
     description: "GPL NETBIOS SMB IActivation unicode andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203840,8 +202473,7 @@ rules:
     private: true
   - name: "sid:2103384"
     description: "GPL NETBIOS SMB IActivation unicode little endian andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203878,8 +202510,7 @@ rules:
     private: true
   - name: "sid:2103397"
     description: "GPL NETBIOS SMB ISystemActivator andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203916,8 +202547,7 @@ rules:
     private: true
   - name: "sid:2103398"
     description: "GPL NETBIOS SMB ISystemActivator little endian andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203954,8 +202584,7 @@ rules:
     private: true
   - name: "sid:2103399"
     description: "GPL NETBIOS SMB ISystemActivator unicode andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -203992,8 +202621,7 @@ rules:
     private: true
   - name: "sid:2103400"
     description: "GPL NETBIOS SMB ISystemActivator unicode little endian andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204030,8 +202658,7 @@ rules:
     private: true
   - name: "sid:2103244"
     description: "GPL NETBIOS SMB irot andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204068,8 +202695,7 @@ rules:
     private: true
   - name: "sid:2103245"
     description: "GPL NETBIOS SMB irot little endian andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204106,8 +202732,7 @@ rules:
     private: true
   - name: "sid:2103246"
     description: "GPL NETBIOS SMB irot unicode andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204144,8 +202769,7 @@ rules:
     private: true
   - name: "sid:2103247"
     description: "GPL NETBIOS SMB irot unicode little endian andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204182,8 +202806,7 @@ rules:
     private: true
   - name: "sid:2103102"
     description: "GPL NETBIOS SMB llsrpc andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204219,8 +202842,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103103"
     description: "GPL NETBIOS SMB llsrpc little endian andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204256,8 +202878,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103104"
     description: "GPL NETBIOS SMB llsrpc unicode andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204293,8 +202914,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103105"
     description: "GPL NETBIOS SMB llsrpc unicode little endian andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204330,8 +202950,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103164"
     description: "GPL NETBIOS SMB msqueue andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204368,8 +202987,7 @@ rules:
     private: true
   - name: "sid:2103165"
     description: "GPL NETBIOS SMB msqueue little endian andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204406,8 +203024,7 @@ rules:
     private: true
   - name: "sid:2103166"
     description: "GPL NETBIOS SMB msqueue unicode andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204444,8 +203061,7 @@ rules:
     private: true
   - name: "sid:2103167"
     description: "GPL NETBIOS SMB msqueue unicode little endian andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204482,8 +203098,7 @@ rules:
     private: true
   - name: "sid:2103206"
     description: "GPL NETBIOS SMB winreg andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204520,8 +203135,7 @@ rules:
     private: true
   - name: "sid:2103207"
     description: "GPL NETBIOS SMB winreg little endian andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204558,8 +203172,7 @@ rules:
     private: true
   - name: "sid:2103208"
     description: "GPL NETBIOS SMB winreg unicode andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204596,8 +203209,7 @@ rules:
     private: true
   - name: "sid:2103209"
     description: "GPL NETBIOS SMB winreg unicode little endian andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204634,8 +203246,7 @@ rules:
     private: true
   - name: "sid:2103389"
     description: "GPL NETBIOS SMB-DS IActivation andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204672,8 +203283,7 @@ rules:
     private: true
   - name: "sid:2103390"
     description: "GPL NETBIOS SMB-DS IActivation little endian andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204710,8 +203320,7 @@ rules:
     private: true
   - name: "sid:2103391"
     description: "GPL NETBIOS SMB-DS IActivation unicode andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204748,8 +203357,7 @@ rules:
     private: true
   - name: "sid:2103392"
     description: "GPL NETBIOS SMB-DS IActivation unicode little endian andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204786,8 +203394,7 @@ rules:
     private: true
   - name: "sid:2103405"
     description: "GPL NETBIOS SMB-DS ISystemActivator andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204824,8 +203431,7 @@ rules:
     private: true
   - name: "sid:2103406"
     description: "GPL NETBIOS SMB-DS ISystemActivator little endian andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204862,8 +203468,7 @@ rules:
     private: true
   - name: "sid:2103407"
     description: "GPL NETBIOS SMB-DS ISystemActivator unicode andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204900,8 +203505,7 @@ rules:
     private: true
   - name: "sid:2103408"
     description: "GPL NETBIOS SMB-DS ISystemActivator unicode little endian andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204938,8 +203542,7 @@ rules:
     private: true
   - name: "sid:2103252"
     description: "GPL NETBIOS SMB-DS irot andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -204976,8 +203579,7 @@ rules:
     private: true
   - name: "sid:2103253"
     description: "GPL NETBIOS SMB-DS irot little endian andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205014,8 +203616,7 @@ rules:
     private: true
   - name: "sid:2103254"
     description: "GPL NETBIOS SMB-DS irot unicode andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205052,8 +203653,7 @@ rules:
     private: true
   - name: "sid:2103255"
     description: "GPL NETBIOS SMB-DS irot unicode little endian andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205090,8 +203690,7 @@ rules:
     private: true
   - name: "sid:2103110"
     description: "GPL NETBIOS SMB-DS llsrpc andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205127,8 +203726,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103111"
     description: "GPL NETBIOS SMB-DS llsrpc little endian andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205164,8 +203762,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103112"
     description: "GPL NETBIOS SMB-DS llsrpc unicode andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205201,8 +203798,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103113"
     description: "GPL NETBIOS SMB-DS llsrpc unicode little endian andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205238,8 +203834,7 @@ rules:
         flag: "smb.tree.bind.llsrpc"
   - name: "sid:2103172"
     description: "GPL NETBIOS SMB-DS msqueue andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205276,8 +203871,7 @@ rules:
     private: true
   - name: "sid:2103173"
     description: "GPL NETBIOS SMB-DS msqueue little endian andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205314,8 +203908,7 @@ rules:
     private: true
   - name: "sid:2103174"
     description: "GPL NETBIOS SMB-DS msqueue unicode andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205352,8 +203945,7 @@ rules:
     private: true
   - name: "sid:2103175"
     description: "GPL NETBIOS SMB-DS msqueue unicode little endian andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205390,8 +203982,7 @@ rules:
     private: true
   - name: "sid:2103215"
     description: "GPL NETBIOS SMB-DS winreg little endian andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205428,8 +204019,7 @@ rules:
     private: true
   - name: "sid:2103216"
     description: "GPL NETBIOS SMB-DS winreg unicode andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205466,8 +204056,7 @@ rules:
     private: true
   - name: "sid:2103217"
     description: "GPL NETBIOS SMB-DS winreg unicode little endian andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205536,8 +204125,7 @@ rules:
         flag: "is_proto_irc"
   - name: "sid:2102991"
     description: "GPL NETBIOS SMB-DS winreg unicode andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205566,8 +204154,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2102960"
     description: "GPL NETBIOS SMB nddeapi andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205596,8 +204183,7 @@ rules:
         flag: "smb.tree.bind.nddeapi"
   - name: "sid:2102956"
     description: "GPL NETBIOS SMB nddeapi andx create tree attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205626,8 +204212,7 @@ rules:
         flag: "smb.tree.create.nddeapi"
   - name: "sid:2102961"
     description: "GPL NETBIOS SMB nddeapi unicode andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205656,8 +204241,7 @@ rules:
         flag: "smb.tree.bind.nddeapi"
   - name: "sid:2102957"
     description: "GPL NETBIOS SMB nddeapi unicode andx create tree attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205686,8 +204270,7 @@ rules:
         flag: "smb.tree.create.nddeapi"
   - name: "sid:2102988"
     description: "GPL NETBIOS SMB winreg andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205716,8 +204299,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2102984"
     description: "GPL NETBIOS SMB winreg andx create tree attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205746,8 +204328,7 @@ rules:
         flag: "smb.tree.create.winreg"
   - name: "sid:2102989"
     description: "GPL NETBIOS SMB winreg unicode andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205776,8 +204357,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2102985"
     description: "GPL NETBIOS SMB winreg unicode andx create tree attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205806,8 +204386,7 @@ rules:
         flag: "smb.tree.create.winreg"
   - name: "sid:2102954"
     description: "GPL NETBIOS SMB-DS IPC$ andx share access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205834,8 +204413,7 @@ rules:
         flag: "smb.tree.connect.ipc"
   - name: "sid:2102955"
     description: "GPL NETBIOS SMB-DS IPC$ unicode andx share access"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205862,8 +204440,7 @@ rules:
         flag: "smb.tree.connect.ipc"
   - name: "sid:2102962"
     description: "GPL NETBIOS SMB-DS nddeapi andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205892,8 +204469,7 @@ rules:
         flag: "smb.tree.bind.nddeapi"
   - name: "sid:2102958"
     description: "GPL NETBIOS SMB-DS nddeapi andx create tree attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205922,8 +204498,7 @@ rules:
         flag: "smb.tree.create.nddeapi"
   - name: "sid:2102963"
     description: "GPL NETBIOS SMB-DS nddeapi unicode andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205952,8 +204527,7 @@ rules:
         flag: "smb.tree.bind.nddeapi"
   - name: "sid:2102959"
     description: "GPL NETBIOS SMB-DS nddeapi unicode andx create tree attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -205982,8 +204556,7 @@ rules:
         flag: "smb.tree.create.nddeapi"
   - name: "sid:2102990"
     description: "GPL NETBIOS SMB-DS winreg andx bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -206012,8 +204585,7 @@ rules:
         flag: "smb.tree.bind.winreg"
   - name: "sid:2102986"
     description: "GPL NETBIOS SMB-DS winreg andx create tree attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -206042,8 +204614,7 @@ rules:
         flag: "smb.tree.create.winreg"
   - name: "sid:2102987"
     description: "GPL NETBIOS SMB-DS winreg unicode andx create tree attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -206102,8 +204673,7 @@ rules:
         flag: "ET.IRC.BOT.CntSOCPU"
   - name: "sid:2019738"
     description: "ET MALWARE AlienSpy RAT Checkin Set"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -206320,8 +204890,7 @@ rules:
         flag: "BE.Radmin.Auth.Challenge"
   - name: "sid:2024173"
     description: "ET MALWARE Red Leaves magic packet detected (APT10 implant)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -206509,8 +205078,7 @@ rules:
         flag: "ET.HB.Request.SI"
   - name: "sid:2019901"
     description: "ET MALWARE VirRansom/VirLock Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -206527,8 +205095,7 @@ rules:
     private: true
   - name: "sid:2020154"
     description: "ET MALWARE Win32/Recslurp.D C2 Request (no alert)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -206623,8 +205190,7 @@ rules:
     private: true
   - name: "sid:2028918"
     description: "ET MALWARE Netwire RAT Client Check-in (socket created)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -206640,8 +205206,7 @@ rules:
         flag: "ET.NetwireRAT.Client"
   - name: "sid:2003555"
     description: "ET MALWARE Bandook v1.35 Initial Connection and Report"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -206662,8 +205227,7 @@ rules:
         flag: "BE.Bandook1.35"
   - name: "sid:2029352"
     description: "ET MALWARE Parallax CnC Activity M6 (set)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -206678,8 +205242,7 @@ rules:
     private: true
   - name: "sid:2029353"
     description: "ET MALWARE Parallax CnC Response Activity M6"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -206693,8 +205256,7 @@ rules:
         flag: "ET.Parallax-6"
   - name: "sid:2029455"
     description: "ET MALWARE Parallax CnC Activity M7 (set)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -206709,8 +205271,7 @@ rules:
     private: true
   - name: "sid:2029456"
     description: "ET MALWARE Parallax CnC Response Activity M7"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -206724,8 +205285,7 @@ rules:
         flag: "ET.Parallax-7"
   - name: "sid:2029814"
     description: "ET MALWARE Parallax CnC Activity M8 (set)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -206740,8 +205300,7 @@ rules:
     private: true
   - name: "sid:2029815"
     description: "ET MALWARE Parallax CnC Response Activity M8"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -206795,8 +205354,7 @@ rules:
         flag: "et.exploitkitlanding"
   - name: "sid:2030027"
     description: "ET MALWARE Parallax CnC Activity M9 (set)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -206811,8 +205369,7 @@ rules:
     private: true
   - name: "sid:2030039"
     description: "ET MALWARE Parallax CnC Response Activity M9"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -206839,8 +205396,7 @@ rules:
         flag: "ET.Fiesta.Exploit.URI"
   - name: "sid:2030180"
     description: "ET MALWARE Parallax CnC Activity M10 (set)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -206855,8 +205411,7 @@ rules:
     private: true
   - name: "sid:2030181"
     description: "ET MALWARE Parallax CnC Response Activity M10"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -207036,8 +205591,7 @@ rules:
         flag: "et.exploitkitlanding"
   - name: "sid:2030888"
     description: "ET INFO [401TRG] RPCNetlogon UUID (CVE-2020-1472) (Set)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -207082,8 +205636,7 @@ rules:
     private: true
   - name: "sid:2032542"
     description: "ET MALWARE Ozone/Darktrack RAT Variant - Client Hello (set)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -207252,8 +205805,7 @@ rules:
     private: true
   - name: "sid:2017936"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 12"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -207267,8 +205819,7 @@ rules:
         flag: "ET.gh0stFmly"
   - name: "sid:2032527"
     description: "ET MALWARE Parallax CnC Response Activity M14"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -207285,8 +205836,7 @@ rules:
         flag: "ET.Parallax-14"
   - name: "sid:2032526"
     description: "ET MALWARE Parallax CnC Activity (set) M14"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -207304,8 +205854,7 @@ rules:
     private: true
   - name: "sid:2034432"
     description: "ET MALWARE Parallax CnC Activity (set) M16"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -207320,8 +205869,7 @@ rules:
     private: true
   - name: "sid:2034431"
     description: "ET MALWARE Parallax CnC Response Activity M15"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -207338,8 +205886,7 @@ rules:
         flag: "ET.Parallax-15"
   - name: "sid:2034430"
     description: "ET MALWARE Parallax CnC Activity (set) M15"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -207357,8 +205904,7 @@ rules:
     private: true
   - name: "sid:2034433"
     description: "ET MALWARE Parallax CnC Response Activity M16"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -207372,8 +205918,7 @@ rules:
         flag: "ET.Parallax-16"
   - name: "sid:2034719"
     description: "ET INFO LDAPSv3 LDAPS_START_TLS Request Outbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -207405,8 +205950,7 @@ rules:
         flag: "ET.RMIRequest"
   - name: "sid:2034748"
     description: "ET INFO Serialized Java Payload via RMI Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -207420,8 +205964,7 @@ rules:
         flag: "ET.RMIRequest"
   - name: "sid:2034749"
     description: "ET INFO Unserialized Java Payload via RMI Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -207435,8 +205978,7 @@ rules:
         flag: "ET.RMIRequest"
   - name: "sid:2034704"
     description: "ET INFO Anonymous LDAPv3 Bind Request Outbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -207454,8 +205996,7 @@ rules:
         flag: "ET.LDAPAnonBindRequest"
   - name: "sid:2034812"
     description: "ET INFO Non-Anonymous LDAPv3 Bind Request Outbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -207534,8 +206075,7 @@ rules:
         flag: "ET.ApacheSpark_UnauthRegisterApplication"
   - name: "sid:2035066"
     description: "ET MALWARE Parallax CnC Activity M17 (set)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -207550,8 +206090,7 @@ rules:
     private: true
   - name: "sid:2035067"
     description: "ET MALWARE Parallax CnC Response Activity M17"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -207832,8 +206371,7 @@ rules:
         flag: "ET.tvt_stage1"
   - name: "sid:2035476"
     description: "ET HUNTING PNG image exfiltration over raw TCP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -207883,8 +206421,7 @@ rules:
     private: true
   - name: "sid:2029477"
     description: "ET MALWARE Netwire RAT Check-in (set)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -207917,8 +206454,7 @@ rules:
         flag: "ET.NetwireRAT.Client"
   - name: "sid:2025035"
     description: "ET MALWARE Netwire RAT Check-in 2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -207934,8 +206470,7 @@ rules:
         flag: "ET.NetwireRAT.Client"
   - name: "sid:2025036"
     description: "ET MALWARE Netwire RAT Check-in 2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -207951,8 +206486,7 @@ rules:
         flag: "ET.NetwireRAT.Client"
   - name: "sid:2036613"
     description: "ET MALWARE Win32/NetDooka Framework RAT Sending Session ID"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -208273,8 +206807,7 @@ rules:
         flag: "ET.darkvision_cnc"
   - name: "sid:2046661"
     description: "ET MALWARE [ANY.RUN] Gh0stBins Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -208290,8 +206823,7 @@ rules:
         flag: "srvrespghostbins"
   - name: "sid:2046662"
     description: "ET MALWARE [ANY.RUN] Possible Gh0stRat Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -208640,8 +207172,7 @@ rules:
         flag: "ET.http.javaclient.vulnerable"
   - name: "sid:2046294"
     description: "ET MALWARE Mystic Stealer C2 Client Hello Packet"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -208841,8 +207372,7 @@ rules:
         flag: "et.shadyratinit"
   - name: "sid:2013409"
     description: "ET INFO Outbound MSSQL Connection to Non-Standard Port - Likely Malware"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -209078,8 +207608,7 @@ rules:
     private: true
   - name: "sid:2022584"
     description: "ET INFO Possible SSLv2 Negotiation in Progress Client Master Key SSL2_RC4_128_WITH_MD5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -209093,8 +207622,7 @@ rules:
         flag: "SSlv2.ServerHello"
   - name: "sid:2022585"
     description: "ET INFO Possible SSLv2 Negotiation in Progress Client Master Key SSL2_RC2_128_CBC_WITH_MD5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -209108,8 +207636,7 @@ rules:
         flag: "SSlv2.ServerHello"
   - name: "sid:2022586"
     description: "ET INFO Possible SSLv2 Negotiation in Progress Client Master Key SSL2_RC2_128_CBC_EXPORT40_WITH_MD5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -209123,8 +207650,7 @@ rules:
         flag: "SSlv2.ServerHello"
   - name: "sid:2022587"
     description: "ET INFO Possible SSLv2 Negotiation in Progress ClientMaster Key SSL2_IDEA_128_CBC_WITH_MD5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -209221,8 +207747,7 @@ rules:
         flag: "ET.telnet.busybox"
   - name: "sid:2024208"
     description: "ET EXPLOIT Possible ETERNALROMANCE MS17-010"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,4}(?-i:�SMB%\u0005\u0000\u0000�).{0,}(?-i:LSbfLScnLSepLSlfLSmf).{0,20}(?-i:LSrfLSsrLSscLSblLSss).{0,20}(?-i:LSshLStrLStcLSopLScd)"
@@ -209235,8 +207760,7 @@ rules:
         flag: "ETPRO.ETERNALROMANCE"
   - name: "sid:2024212"
     description: "ET EXPLOIT Possible ETERNALCHAMPION MS17-010 Sync Request (set)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,4}(?-i:�SMB%\u0000\u0000\u0000\u0000\u0018\u0003�\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000).{10,17}(?-i:\u0000\u0000\u0000\u0000����\u0000\u0000).{13,26}(?-i:\\\\\u0000P\u0000I\u0000P\u0000E\u0000\\\\\u0000L\u0000A\u0000N\u0000M\u0000A\u0000N\u0000\u0000\u0000).{0,19}(?-i:�\u0000zb12g12DWrLehig24)"
@@ -209250,8 +207774,7 @@ rules:
     private: true
   - name: "sid:2024218"
     description: "ET EXPLOIT Possible ETERNALBLUE MS17-010 Echo Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,0}(?-i:\u0000\u0000\u00001�SMB\\+\u0000\u0000\u0000\u0000�\u0007�).{0,}(?-i:JlJmIhClBsr\u0000)"
@@ -209264,8 +207787,7 @@ rules:
         flag: "ET.ETERNALBLUE"
   - name: "sid:2024220"
     description: "ET EXPLOIT Possible ETERNALBLUE MS17-010 Echo Request (set)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,0}(?-i:\u0000\u0000\u00001�SMB\\+\u0000\u0000\u0000\u0000\u0018\u0007�).{0,}(?-i:JlJmIhClBsr\u0000)"
@@ -209675,8 +208197,7 @@ rules:
         flag: "is_proto_irc"
   - name: "sid:2102193"
     description: "GPL NETBIOS SMB-DS DCERPC ISystemActivator bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -209703,8 +208224,7 @@ rules:
         flag: "dce.isystemactivator.bind.call.attempt"
   - name: "sid:2102491"
     description: "GPL NETBIOS SMB-DS DCERPC ISystemActivator unicode bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -209767,8 +208287,7 @@ rules:
         flag: "dce.isystemactivator.bind.call.attempt"
   - name: "sid:2102507"
     description: "GPL NETBIOS DCERPC LSASS bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -209796,8 +208315,7 @@ rules:
     private: true
   - name: "sid:2102510"
     description: "GPL NETBIOS SMB DCERPC LSASS bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -209834,8 +208352,7 @@ rules:
     private: true
   - name: "sid:2102512"
     description: "GPL NETBIOS SMB-DS DCERPC LSASS bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -209863,8 +208380,7 @@ rules:
     private: true
   - name: "sid:2102513"
     description: "GPL NETBIOS SMB-DS DCERPC LSASS unicode bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -209892,8 +208408,7 @@ rules:
     private: true
   - name: "sid:2102524"
     description: "GPL NETBIOS DCERPC LSASS direct bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -209911,8 +208426,7 @@ rules:
     private: true
   - name: "sid:2102525"
     description: "GPL NETBIOS SMB DCERPC LSASS direct bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -209930,8 +208444,7 @@ rules:
     private: true
   - name: "sid:2102526"
     description: "GPL NETBIOS SMB-DS DCERPC LSASS direct bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -209978,8 +208491,7 @@ rules:
         flag: "ET.wacatacstealer"
   - name: "sid:2103156"
     description: "GPL NETBIOS DCERPC msqueue bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -210007,8 +208519,7 @@ rules:
     private: true
   - name: "sid:2103157"
     description: "GPL NETBIOS DCERPC msqueue little endian bind attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -210036,8 +208547,7 @@ rules:
     private: true
   - name: "sid:2103274"
     description: "GPL EXPLOIT login buffer non-evasive overflow attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -210056,8 +208566,7 @@ rules:
         flag: "ttyprompt"
   - name: "sid:2012520"
     description: "ET WEB_CLIENT Microsoft OLE Compound File Magic Bytes Flowbit Set"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,8}(?-i:��\u0011ࡱ\u001a�)"
@@ -210216,8 +208725,7 @@ rules:
         flag: "et.exploitkitlanding"
   - name: "sid:2016502"
     description: "ET INFO JAVA - Java Serialized Data Download by Vulnerable Client"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,2}(?-i:��)"
@@ -210232,8 +208740,7 @@ rules:
         flag: "et.exploitkitlanding"
   - name: "sid:2016503"
     description: "ET INFO JAVA - Java Serialized Data Download"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,2}(?-i:��)"
@@ -210378,8 +208885,7 @@ rules:
         flag: "et.exploitkitlanding"
   - name: "sid:2016970"
     description: "ET MALWARE Karagany encrypted binary (3)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,8}(?-i:���\u0000��\u0000\u0000)"
@@ -210643,8 +209149,7 @@ rules:
     private: true
   - name: "sid:2017749"
     description: "ET INFO Java Downloading Class flowbit no alert"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,4}(?-i:����)"
@@ -210744,8 +209249,7 @@ rules:
         flag: "ET.WireLurkerUA"
   - name: "sid:2019834"
     description: "ET INFO Microsoft Compact Office Document Format File Download"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,8}(?-i:��\u0011ࡱ\u001a�)"
@@ -210859,8 +209363,7 @@ rules:
         flag: "SunDown.EK"
   - name: "sid:2021725"
     description: "ET MALWARE Cryptowall docs campaign Aug 2015 encrypted binary (1)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,8}(?-i:e\\]�ư�hb)"
@@ -210873,8 +209376,7 @@ rules:
         flag: "et.exploitkitlanding"
   - name: "sid:2021778"
     description: "ET MALWARE Cryptowall docs campaign Sept 2015 encrypted binary (1)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,8}(?-i:\\#1�ObWsg)"
@@ -211058,8 +209560,7 @@ rules:
         flag: "ET.RIGEKExploit"
   - name: "sid:2024608"
     description: "ET EXPLOIT_KIT Disdain EK Payload Aug 23 2017"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,8}(?-i:0\\&�=��\\[\u0016)"
@@ -211502,8 +210003,7 @@ rules:
         flag: "ET.gadu.loggedin"
   - name: "sid:2006397"
     description: "ET MALWARE Socks666 Successful Connect Packet Packet"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -211521,8 +210021,7 @@ rules:
         flag: "BS.BPcheckin"
   - name: "sid:2016659"
     description: "ET MALWARE [CrowdStrike] ANCHOR PANDA Torn RAT Beacon Message Header Local"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -211539,8 +210038,7 @@ rules:
     private: true
   - name: "sid:2024174"
     description: "ET MALWARE Red Leaves magic packet response detected (APT10 implant)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -211644,8 +210142,7 @@ rules:
         flag: "BE.Radmin.Auth.Challenge"
   - name: "sid:2006396"
     description: "ET MALWARE Socks666 Connect Command Packet"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -212159,8 +210656,7 @@ rules:
       established: true
   - name: "sid:2001195"
     description: "ET EXPLOIT libPNG - Possible integer overflow in allocation in png_handle_sPLT"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -212196,8 +210692,7 @@ rules:
       established: true
   - name: "sid:2001259"
     description: "ET CHAT Yahoo IM file transfer request"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -213203,8 +211698,7 @@ rules:
       to_server: true
   - name: "sid:2051761"
     description: "ET MALWARE Possible HijackLoader Second Stage PNG Retrieval"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�PNG\\\r\\\n\u001a\\\n).{0,50}(?-i:IDATƥy�)"
@@ -220599,8 +219093,7 @@ rules:
       to_server: true
   - name: "sid:2034036"
     description: "ET MALWARE Possible FoggyWeb Backdoor Server Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:image/webp).*?(?-i:RIFF).{4,8}(?-i:WEBPVP8\\ ).{4,6}(?-i:\u00102\u0000�\u0001\\*).*?(?-i:^[\\x80|\\x40]\\x00[\\x80|\\x40]\\x00\\x00\\x00)"
@@ -223910,8 +222403,7 @@ rules:
       case_insensitive: false
   - name: "sid:2037027"
     description: "ET MALWARE CopperStealer - Browser Stealer Exfil via Telegram"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:/bot).*?(?-i:/sendDocument).*?(?-i:multipart/form\\-data;\\ boundary=\\-\\-\\-\\-WebKitFormBoundaryovEAlxca0DiIz7tl).*?(?-i:Content\\-Disposition:\\ form\\-data;\\ name=\"document\";\\ filename=\").{36,85}(?-i:\\.zip\"\\\r\\\nContent\\-Type:\\ application/x\\-zip\\-compressed\\\r\\\n\\\r\\\n7z��'\u001c)"
@@ -226874,8 +225366,7 @@ rules:
       to_server: true
   - name: "sid:2044061"
     description: "ET MALWARE UAC-0114/Winter Vivern Screenshot Upload M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:\\.php).*?(?-i:filename:\\ S\\-1\\-).*?(?-i:application/x\\-www\\-form\\-urlencoded).*?(?-i:�PNG\\\r\\\n\u001a\\\n)"
@@ -238166,8 +236657,7 @@ rules:
       to_server: true
   - name: "sid:2030109"
     description: "ET MALWARE nspps Backdoor - Sending SOCKS Details"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST\\ /s\\ HTTP/1\\.1\\\r\\\n).*?(?-i:WztG�D�\\|�)"
@@ -238370,8 +236860,7 @@ rules:
       to_server: true
   - name: "sid:2029335"
     description: "ET MALWARE Mimikatz x64 Executable Download Over HTTP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:3�).{1,2}(?-i:�7).{1,4}(?-i:��E�).{1}(?-i:t).*?(?-i:L��I).{0,7}(?-i:��\u0004H).{0,7}(?-i:��L\u0003).{0,4}(?-i:�)"
@@ -238384,8 +236873,7 @@ rules:
         flag: "ET.http.binary"
   - name: "sid:2029334"
     description: "ET MALWARE Mimikatz x86 Executable Download Over HTTP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�q\u0004�).{0,7}(?-i:0�\u0004�).*?(?-i:�M).{1,5}(?-i:�E�u).{1,5}(?-i:�\u0001��t)"
@@ -238780,8 +237268,7 @@ rules:
       to_server: true
   - name: "sid:2051947"
     description: "ET MALWARE Suspected Parallax RAT Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -239278,8 +237765,7 @@ rules:
       to_server: true
   - name: "sid:2025836"
     description: "ET EXPLOIT Adobe Coldfusion BlazeDS Java Object Deserialization Remote Code Execution"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:/amf).*?(?-i:sun\\.rmi\\.server\\.UnicastRef).{0,}(?-i:�jv\\{\\|�hOvت=\u0000\u0000\u0001\\[�L\u001d��\u0001\u0000)"
@@ -239682,8 +238168,7 @@ rules:
       to_server: true
   - name: "sid:2023185"
     description: "ET EXPLOIT Possible Android Stagefright MP4 (CVE 2016-3861) ROP"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:ID3).{0,800}(?-i:A�A�A�A�A�A�).*?(?-i:^(\\x41\\xd8\\x41\\xd8\\x41\\xdc){2,}\\x41\\x00)"
@@ -240276,8 +238761,7 @@ rules:
       to_server: true
   - name: "sid:2019187"
     description: "ET MALWARE Kuluoz/Asprox CnC Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�\u0000\u0000\u0000)"
@@ -240770,8 +239254,7 @@ rules:
       to_server: true
   - name: "sid:2016656"
     description: "ET MALWARE [CrowdStrike] ANCHOR PANDA - Adobe Gh0st Beacon"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -240802,8 +239285,7 @@ rules:
       to_server: true
   - name: "sid:2024793"
     description: "ET ADWARE_PUP [PTsecurity] DeathBot.Java (Minecraft Spambot)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -241577,8 +240059,7 @@ rules:
       to_server: true
   - name: "sid:2015896"
     description: "ET MALWARE Andromeda Check-in Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:Content\\-Length:\\ 9\\\r\\\n).{0,4}(?-i:l�2�)"
@@ -242091,8 +240572,7 @@ rules:
       to_client: true
   - name: "sid:2015028"
     description: "ET MALWARE Cridex Post to CnC"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:ޭ��)"
@@ -242302,8 +240782,7 @@ rules:
       to_server: true
   - name: "sid:2014870"
     description: "ET INFO SN and CN From MS TS Revoked Cert Chain Seen"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�\u0000�<<�\u0011�>�c��@).{24,105}(?-i:Microsoft\\ Root\\ Authority).{0,}(?-i:Microsoft\\ Enforced\\ Licensing\\ Intermediate\\ PCA).{0,}(?-i:a\u001a\u0002�\u0000\u0002\u0000\u0000\u0000\u0012).{54,378}(?-i:Microsoft\\ Enforced\\ Licensing\\ Registration\\ Authority\\ CA)"
@@ -242663,8 +241142,7 @@ rules:
       to_client: true
   - name: "sid:2014517"
     description: "ET INFO EXE - OSX Executable Download - PowerPC Arch"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:����).{0,}(?-i:__TEXT)"
@@ -242674,8 +241152,7 @@ rules:
       to_client: true
   - name: "sid:2014516"
     description: "ET INFO EXE - OSX Executable Download - Intel Arch"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:����).{0,}(?-i:__TEXT)"
@@ -242685,8 +241162,7 @@ rules:
       to_client: true
   - name: "sid:2014515"
     description: "ET INFO EXE - OSX Executable Download - Multi Arch w/PowerPC"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:����).{0,}(?-i:����).{0,}(?-i:__TEXT)"
@@ -242696,8 +241172,7 @@ rules:
       to_client: true
   - name: "sid:2014514"
     description: "ET INFO EXE - OSX Executable Download - Multi Arch w/Intel"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:����).{0,}(?-i:����).{0,}(?-i:__TEXT)"
@@ -242707,8 +241182,7 @@ rules:
       to_client: true
   - name: "sid:2014475"
     description: "ET INFO JAVA - Java Class Download By Vulnerable Client"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:����)"
@@ -242721,8 +241195,7 @@ rules:
         flag: "ET.http.javaclient.vulnerable"
   - name: "sid:2014474"
     description: "ET INFO JAVA - Java Class Download"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:����)"
@@ -243789,8 +242262,7 @@ rules:
         flag: "ET.flash.pdf"
   - name: "sid:2013281"
     description: "ET WEB_CLIENT Adobe Authplay.dll NewClass Memory Corruption Attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�`8@�\u0003\u0014\u000e)"
@@ -244033,8 +242505,7 @@ rules:
       to_client: true
   - name: "sid:2013070"
     description: "ET WEB_CLIENT Adobe Shockwave Director tSAC Chunk memory corruption Attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:tSAC\u001d\u0002).{0,}(?-i:\u0001\u0000��\u0011\u0011)"
@@ -244271,8 +242742,7 @@ rules:
       to_client: true
   - name: "sid:2012814"
     description: "ET WEB_CLIENT PDF With Adobe Audition Session File Handling Memory Corruption Attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:COOLNESSP�\u0008\u0000)"
@@ -245414,8 +243884,7 @@ rules:
       to_client: true
   - name: "sid:2011575"
     description: "ET WEB_CLIENT Adobe Acrobat newfunction Remote Code Execution Attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:@����3)"
@@ -245468,8 +243937,7 @@ rules:
       to_server: true
   - name: "sid:2011543"
     description: "ET WEB_CLIENT Adobe Shockwave Director tSAC Chunk memory corruption Attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:tSAC\u001d\u0002\u0000\u0000\u0000\u0000\u0000\u000f\u0000\u0000\u0000�\u0000\u0000\u0001c\u0000\u0000\u0000\u0014\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0004\u0000\u0000\u0000\u0000\u0000\u0014\u0000\u0000\u0001\u0000��\u0011\u0011\u0000\u0000)"
@@ -245512,8 +243980,7 @@ rules:
       to_client: true
   - name: "sid:2011519"
     description: "ET WEB_CLIENT Possible Adobe Acrobat Reader Newclass Invalid Pointer Remote Code Execution Attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�=�\\#)"
@@ -245536,8 +244003,7 @@ rules:
       to_client: true
   - name: "sid:2011500"
     description: "ET WEB_CLIENT Possible Adobe Acrobat and Reader Pushstring Memory Corruption Attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:,���3)"
@@ -249218,8 +247684,7 @@ rules:
       to_server: true
   - name: "sid:2024533"
     description: "ET MALWARE [PTsecurity] Gozi/Ursnif Payload v12"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:X\u001b�c��\u0005\u0014\\&�J�u��\\&�<\u0011nqB�\\&�z\u0008RT/1\u007fX���!�M��b���eݱ)"
@@ -249560,8 +248025,7 @@ rules:
     private: true
   - name: "sid:2024908"
     description: "ET MALWARE Qtloader encrypted check-in Oct 19 M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:,E2M�8U)"
@@ -249780,8 +248244,7 @@ rules:
       to_server: true
   - name: "sid:2025457"
     description: "ET MALWARE [PTsecurity] W32/Rodecap.StealRat C2 Payload (GIF)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:GIF89a\u0010\u0000\u0010\u0000�\u0000\u0000���������\u0000\u0000\u0000!�\u0004\u0000\u0000\u0000\u0000_\u0005����������m���\\*\\*\\*\\*\\*\\*\\*\\*jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj)"
@@ -250285,8 +248748,7 @@ rules:
       to_server: true
   - name: "sid:2035054"
     description: "ET MALWARE Win32/Emotet CnC Checkin Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     src_port:
       ports: [7080, 8080, 443, 80, 4143, 995, 21, 50000, 20, 8090, 8443, 990, 22]
@@ -250711,8 +249173,7 @@ rules:
       to_server: true
   - name: "sid:2027737"
     description: "ET EXPLOIT Possible WebShell JPEG Upload"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:����).{2,4}(?-i:JFIF).{0,}(?-i:<%eval\\ request\\(\")"
@@ -251759,8 +250220,7 @@ rules:
       to_server: true
   - name: "sid:2027972"
     description: "ET EXPLOIT HiSilicon DVR - Buffer Overflow in Builtin Web Server"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:GET\\ \u0001\u0010��\u0011�).{0,}(?-i:aaaaaaaa)"
@@ -256699,8 +255159,7 @@ rules:
       to_server: true
   - name: "sid:2019164"
     description: "ET MALWARE JackPOS XOR Encoded HTTP Client Body (key AA)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:��).*?(?-i:����������������)"
@@ -257046,8 +255505,7 @@ rules:
       to_server: true
   - name: "sid:2008271"
     description: "ET MALWARE DMSpammer HTTP Post Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?i:POST).*?(?-i:/stat).*?(?-i:\\.php).*?(?-i:Mozilla/4\\.0\\ \\(compatible;\\ Synapse\\)).*?(?-i:x�).*?(?-i:/stat\\d+\\.php)"
@@ -259410,8 +257868,7 @@ rules:
       to_client: true
   - name: "sid:2026550"
     description: "ET MALWARE MICROPSIA Sending JPG Screenshot to CnC with .his Extension"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:compatible;\\ Googlebot/).*?(?-i:name=\"kerna\";\\ filename).{0,20}(?-i:\\.his\"\\\r\\\n).{0,}(?-i:\\\r\\\n\\\r\\\n���).{0,15}(?-i:JFIF).*?(?-i:UTF8).*?(?-i:multipart/form\\-data;\\ boundary=\\-\\-\\-\\-\\-\\-\\-Embt\\-Boundary)"
@@ -263532,8 +261989,7 @@ rules:
     private: true
   - name: "sid:2025205"
     description: "ET MALWARE [PTsecurity] Gozi/Ursnif Payload v14"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:�,Ư�\\&V�s��h\u000f���)"
@@ -263597,8 +262053,7 @@ rules:
     private: true
   - name: "sid:2025583"
     description: "ET MALWARE [PTsecurity] PS/TrojanDownloader.Agent.NNR XORed Zip payload (key 0x91)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:�ڒ�������)"
@@ -264033,8 +262488,7 @@ rules:
       to_client: true
   - name: "sid:2027739"
     description: "ET MALWARE Possible Outbound WebShell JPEG"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:����).{2,4}(?-i:JFIF).{0,}(?-i:<%eval\\ request\\(\")"
@@ -269698,8 +268152,7 @@ rules:
         flag: "ET.genericphish"
   - name: "sid:2024837"
     description: "ET MALWARE [PTsecurity] Ursnif Encoded Payload Inbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:=�a<y���\u0018�\u0008�UD�A)"
@@ -269971,8 +268424,7 @@ rules:
         flag: "et.exploitkitlanding"
   - name: "sid:2017909"
     description: "ET HUNTING suspicious - uncompressed pack200-ed JAR"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:���\\\r)"
@@ -269987,8 +268439,7 @@ rules:
         flag: "et.exploitkitlanding"
   - name: "sid:2017910"
     description: "ET HUNTING suspicious - gzipped file via JAVA - could be pack200-ed JAR"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u001f�\u0008\u0000)"
@@ -270016,8 +268467,7 @@ rules:
         flag: "ETGamut"
   - name: "sid:2018297"
     description: "ET EXPLOIT_KIT GoonEK encrypted binary (3)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:���j\\$\u001fF\u0014)"
@@ -270030,8 +268480,7 @@ rules:
         flag: "et.exploitkitlanding"
   - name: "sid:2017163"
     description: "ET MOBILE_MALWARE signed-unsigned integer mismatch code-verification bypass"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:PK).{2,26}(?-i:��).{0,128}(?i:\\.dex)"
@@ -270264,8 +268713,7 @@ rules:
       to_server: true
   - name: "sid:2036413"
     description: "ET MALWARE [ESET] TA410 APT LookBack HTTP Server Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:image/gif).*?(?-i:�\\.�H).*?(?-i:^ETag\\x3a\\x20[0-9]{6}-[0-9]{3,5}-[0-9]{8}\\r\\n)"
@@ -270855,8 +269303,7 @@ rules:
       to_client: true
   - name: "sid:2031286"
     description: "ET CURRENT_EVENTS [Fireeye] Backdoor.HTTP.BEACON.[CSBundle Original Stager 2]"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:HTTP/1\\.).*?(?-i:Content\\-Type:\\ text/json\\\r\\\n).*?(?-i:Server:\\ Microsoft\\-IIS/10\\.0\\\r\\\n).*?(?-i:X\\-Powered\\-By:\\ ASP\\.NET\\\r\\\n).*?(?-i:Cache\\-Control:\\ no\\-cache,\\ no\\-store,\\ max\\-age=0,\\ must\\-revalidate\\\r\\\n).*?(?-i:Pragma:\\ no\\-cache\\\r\\\n).*?(?-i:X\\-Frame\\-Options:\\ SAMEORIGIN\\\r\\\n).*?(?-i:Connection:\\ close\\\r\\\n).*?(?-i:Content\\-Type:\\ image/gif).*?(?-i:\u0001\u0000\u0001\u0000\u0000\u0002\u0001D\u0000;).*?(?-i:���!�\u0004\u0001\u0000\u0000\u0000,\u0000\u0000\u0000\u0000).*?(?-i:GIF89a\u0001\u0000\u0001\u0000�\u0000\u0000\u0000\u0000)"
@@ -272503,8 +270950,7 @@ rules:
       to_server: true
   - name: "sid:2017959"
     description: "ET MALWARE W32/Mevade.Variant CnC POST"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:uuid:\\ ).*?(?-i:�q\u0004���w�).*?(?-i:^\\x2F(?:policy|cache)$)"
@@ -274790,8 +273236,7 @@ rules:
       to_server: true
   - name: "sid:2029467"
     description: "ET MALWARE Win32/AZORult V3.3 Client Checkin M14"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).{6,53}(?-i:p�Gp�:p�7p�2p�7p�:p�3p�4\u0014�1\u0011).*?(?-i:^(?:\\x00\\x00\\x00)?(?:[\\x40-\\x42]|[\\x45-\\x47]|\\x26\\x66))"
@@ -275144,8 +273589,7 @@ rules:
       to_server: true
   - name: "sid:2029403"
     description: "ET MALWARE Win32/AZORult V3.2 Client Checkin M3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:J).{10,47}(?-i:�>9�>>�>9�\\(9�HI�\\?N�><).*?(?-i:^(?:[\\x4b-\\x4c]|[\\x48-\\x49]|[\\x4e-\\x4f]|\\x2f\\xfb))"
@@ -277766,8 +276210,7 @@ rules:
       to_server: true
   - name: "sid:2025885"
     description: "ET MALWARE AZORult Variant.4 Checkin M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:\\.php).*?(?-i:J/�).*?(?-i:/�)"
@@ -281062,8 +279505,7 @@ rules:
       to_server: true
   - name: "sid:2052263"
     description: "ET MALWARE Win32/ProcessKiller CnC - Client Side"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -281111,8 +279553,7 @@ rules:
       to_server: true
   - name: "sid:2052264"
     description: "ET MALWARE Win32/ProcessKiller CnC - Server Side"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -281455,8 +279896,7 @@ rules:
       to_server: true
   - name: "sid:2032822"
     description: "ET MALWARE MICROPSIA Screenshot Upload M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:Content\\-Disposition:\\ form\\-data;\\ name=\"jpxnk\";\\ filename=).*?(?-i:\"\\\r\\\nContent\\-Type:\\ utf\\-8\\\r\\\n\\\r\\\n����).{0,40}(?-i:JFIF)"
@@ -281699,8 +280139,7 @@ rules:
       to_server: true
   - name: "sid:2033174"
     description: "ET MALWARE ReverseRAT Activity (POST) M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:C!�9��,\u001cT\u0006).*?(?-i:\\\r\\\nexpect\\\r\\\nconnection\\\r\\\n\\\r\\\n)"
@@ -282492,8 +280931,7 @@ rules:
       to_server: true
   - name: "sid:2034493"
     description: "ET EXPLOIT UPnP UUID Password Change Exploit Attempt Inbound - XR300 PoC Gadgets (CVE-2021-34991)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:SUBSCRIBE).*?(?-i:\\\r\\\nuuid\\\r\\\n).*?(?-i:�\u0005\u0000).{10}(?-i:��\u0002)"
@@ -282503,8 +280941,7 @@ rules:
       to_server: true
   - name: "sid:2034494"
     description: "ET EXPLOIT UPnP UUID Password Change Exploit Attempt Inbound - R6700V3 PoC Gadgets (CVE-2021-34991)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:SUBSCRIBE).*?(?-i:\\\r\\\nuuid\\\r\\\n).*?(?-i:�j\u0006\u0000).{10}(?-i:�\u0001\u0000)"
@@ -282936,8 +281373,7 @@ rules:
       to_server: true
   - name: "sid:2035275"
     description: "ET MALWARE ReverseRat 2.0 CnC Checkin M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:���\u0014\\$\u0002\\.�\\?�)"
@@ -283113,8 +281549,7 @@ rules:
       to_server: true
   - name: "sid:2035635"
     description: "ET EXPLOIT Possible WatchGuard CVE-2022-26318 RCE Attempt M3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST\\ /agent/login).*?(?-i:content\\-encoding:\\ gzip).*?(?-i:\u001f�)"
@@ -284032,8 +282467,7 @@ rules:
       to_server: true
   - name: "sid:2029462"
     description: "ET MALWARE Win32/AZORult V3.3 Client Checkin M12"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).{6,51}(?-i:�1\u0011�\\&f�\\&f�\\&f�Ap�6p�4p�7p�G).*?(?-i:^(?:\\x00\\x00\\x00)?(?:[\\x40-\\x42]|[\\x45-\\x47]|\\x26\\x66))"
@@ -284043,8 +282477,7 @@ rules:
       to_server: true
   - name: "sid:2029446"
     description: "ET MALWARE Win32/AZORult V3.3 Client Checkin M8"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).{6,49}(?-i:p�Gp�4p�1\u0011�0c�0b�0l�Ap�G).*?(?-i:^(?:\\x00\\x00\\x00)?(?:[\\x40-\\x42]|[\\x45-\\x47]|\\x26\\x66))"
@@ -284054,8 +282487,7 @@ rules:
       to_server: true
   - name: "sid:2029447"
     description: "ET MALWARE Win32/AZORult V3.3 Client Checkin M9"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).{6,49}(?-i:�1\u0011�0b�0g�\\&f�\\&f�\\&f�A\u0017�1\u0011).*?(?-i:^(?:\\x00\\x00\\x00)?(?:[\\x40-\\x42]|[\\x45-\\x47]|\\x26\\x66))"
@@ -284065,8 +282497,7 @@ rules:
       to_server: true
   - name: "sid:2029404"
     description: "ET MALWARE Win32/AZORult V3.3 Client Checkin M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).{6,49}(?-i:\\&g�\\&f�\\&f�\\&f�Bp�1\u0010�\\&f�\\&g�).*?(?-i:^(?:\\x00\\x00\\x00)?(?:[\\x40-\\x42]|[\\x45-\\x47]|\\x26\\x66))"
@@ -284076,8 +282507,7 @@ rules:
       to_server: true
   - name: "sid:2029460"
     description: "ET MALWARE Win32/AZORult V3.3 Client Checkin M10"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).{6,51}(?-i:\\&g�Fp�6p�7p�7\u0017�0`�0b�0a�1\u0011).*?(?-i:^(?:\\x00\\x00\\x00)?(?:[\\x40-\\x42]|[\\x45-\\x47]|\\x26\\x66))"
@@ -284087,8 +282517,7 @@ rules:
       to_server: true
   - name: "sid:2029482"
     description: "ET MALWARE Win32/AZORult V3.3 Client Checkin M16"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).{6,43}(?-i:\\&g�@p�2\u0014�G\u0017�0e�\\&g�).*?(?-i:^(?:\\x00\\x00\\x00)?(?:[\\x40-\\x42]|[\\x45-\\x47]|\\x26\\x66))"
@@ -284098,8 +282527,7 @@ rules:
       to_server: true
   - name: "sid:2029445"
     description: "ET MALWARE Win32/AZORult V3.3 Client Checkin M7"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).{6,49}(?-i:\\&g�\\&f�\\&f�Gp�5p�4p�:\u0017�\\&g�).*?(?-i:^(?:\\x00\\x00\\x00)?(?:[\\x40-\\x42]|[\\x45-\\x47]|\\x26\\x66))"
@@ -284109,8 +282537,7 @@ rules:
       to_server: true
   - name: "sid:2034055"
     description: "ET MALWARE Win32/AZORult V3.3 Client Checkin M24"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).{6,47}(?-i:�1\u0011�0g�0f�0d�A\u0010�0c�\\&g�).*?(?-i:^(?:\\x00\\x00\\x00)?(?:[\\x40-\\x42]|[\\x45-\\x47]|\\x26\\x66))"
@@ -284120,8 +282547,7 @@ rules:
       to_server: true
   - name: "sid:2029405"
     description: "ET MALWARE Win32/AZORult V3.3 Client Checkin M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).{6,49}(?-i:p�Gp�0p�7p�0\u0014�0g�@p�5p�G).*?(?-i:^(?:\\x00\\x00\\x00)?(?:[\\x40-\\x42]|[\\x45-\\x47]|\\x26\\x66))"
@@ -284131,8 +282557,7 @@ rules:
       to_server: true
   - name: "sid:2029466"
     description: "ET MALWARE Win32/AZORult V3.3 Client Checkin M13"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).{6,53}(?-i:\\&g�\\&f�\\&f�\\&f�\\&f�\\&f�\\&f�\\&f�Bp�G).*?(?-i:^(?:\\x00\\x00\\x00)?(?:[\\x40-\\x42]|[\\x45-\\x47]|\\x26\\x66))"
@@ -284142,8 +282567,7 @@ rules:
       to_server: true
   - name: "sid:2029489"
     description: "ET MALWARE Win32/AZORult V3.3 Client Checkin M20"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).{6,49}(?-i:p�G\u0017�\\&f�\\&f�\\&f�\\&f�\\&f�Ap�G).*?(?-i:^(?:\\x00\\x00\\x00)?(?:[\\x40-\\x42]|[\\x45-\\x47]|\\x26\\x66))"
@@ -284153,8 +282577,7 @@ rules:
       to_server: true
   - name: "sid:2029488"
     description: "ET MALWARE Win32/AZORult V3.3 Client Checkin M19"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).{6,49}(?-i:\\&g�A\u0011�0e�0m�0a�0a�0c�\\&g�).*?(?-i:^(?:\\x00\\x00\\x00)?(?:[\\x40-\\x42]|[\\x45-\\x47]|\\x26\\x66))"
@@ -284164,8 +282587,7 @@ rules:
       to_server: true
   - name: "sid:2029461"
     description: "ET MALWARE Win32/AZORult V3.3 Client Checkin M11"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).{6,51}(?-i:p�G\u0010�0`�0a�0a�\\&f�\\&f�\\&f�\\&g�).*?(?-i:^(?:\\x00\\x00\\x00)?(?:[\\x40-\\x42]|[\\x45-\\x47]|\\x26\\x66))"
@@ -284175,8 +282597,7 @@ rules:
       to_server: true
   - name: "sid:2034054"
     description: "ET MALWARE Win32/AZORult V3.3 Client Checkin M23"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).{6,47}(?-i:p�Gp�1p�0p�2\u0014�Fp�5\u0017�1\u0011).*?(?-i:^(?:\\x00\\x00\\x00)?(?:[\\x40-\\x42]|[\\x45-\\x47]|\\x26\\x66))"
@@ -284186,8 +282607,7 @@ rules:
       to_server: true
   - name: "sid:2034053"
     description: "ET MALWARE Win32/AZORult V3.3 Client Checkin M22"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).{6,47}(?-i:\\&g�\\&f�\\&f�\\&f�B\u0017�\\&f�Ap�G).*?(?-i:^(?:\\x00\\x00\\x00)?(?:[\\x40-\\x42]|[\\x45-\\x47]|\\x26\\x66))"
@@ -284197,8 +282617,7 @@ rules:
       to_server: true
   - name: "sid:2029439"
     description: "ET MALWARE Win32/AZORult V3.3 Client Checkin M4"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).{6,47}(?-i:\\&g�\\&f�\\&f�@p�0\u0011�@p�4p�G).*?(?-i:^(?:\\x00\\x00\\x00)?(?:[\\x40-\\x42]|[\\x45-\\x47]|\\x26\\x66))"
@@ -284208,8 +282627,7 @@ rules:
       to_server: true
   - name: "sid:2029490"
     description: "ET MALWARE Win32/AZORult V3.3 Client Checkin M21"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).{6,49}(?-i:�1\u0011�Gp�3p�;p�7p�7p�5\u0017�1\u0011).*?(?-i:^(?:\\x00\\x00\\x00)?(?:[\\x40-\\x42]|[\\x45-\\x47]|\\x26\\x66))"
@@ -284219,8 +282637,7 @@ rules:
       to_server: true
   - name: "sid:2029468"
     description: "ET MALWARE Win32/AZORult V3.3 Client Checkin M15"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).{6,53}(?-i:�1\u0011�0l�0a�0d�0a�0l�0e�0b�\\&g�).*?(?-i:^(?:\\x00\\x00\\x00)?(?:[\\x40-\\x42]|[\\x45-\\x47]|\\x26\\x66))"
@@ -284230,8 +282647,7 @@ rules:
       to_server: true
   - name: "sid:2029441"
     description: "ET MALWARE Win32/AZORult V3.3 Client Checkin M6"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).{6,47}(?-i:�1\u0011�0m�0c�\\&f�G\u0013�\\&f�\\&g�).*?(?-i:^(?:\\x00\\x00\\x00)?(?:[\\x40-\\x42]|[\\x45-\\x47]|\\x26\\x66))"
@@ -284241,8 +282657,7 @@ rules:
       to_server: true
   - name: "sid:2029406"
     description: "ET MALWARE Win32/AZORult V3.3 Client Checkin M3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).{6,49}(?-i:�1\u0011�0f�0a�0f�\\&f�F\u0016�0c�1\u0011).*?(?-i:^(?:\\x00\\x00\\x00)?(?:[\\x40-\\x42]|[\\x45-\\x47]|\\x26\\x66))"
@@ -284252,8 +282667,7 @@ rules:
       to_server: true
   - name: "sid:2029484"
     description: "ET MALWARE Win32/AZORult V3.3 Client Checkin M18"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).{6,43}(?-i:�1\u0011�\\&f�B\u0013�Ap�3\u0014�1\u0011).*?(?-i:^(?:\\x00\\x00\\x00)?(?:[\\x40-\\x42]|[\\x45-\\x47]|\\x26\\x66))"
@@ -284263,8 +282677,7 @@ rules:
       to_server: true
   - name: "sid:2029440"
     description: "ET MALWARE Win32/AZORult V3.3 Client Checkin M5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).{6,47}(?-i:p�Gp�;p�5\u0016�0f�E\u0016�0b�1\u0011).*?(?-i:^(?:\\x00\\x00\\x00)?(?:[\\x40-\\x42]|[\\x45-\\x47]|\\x26\\x66))"
@@ -284274,8 +282687,7 @@ rules:
       to_server: true
   - name: "sid:2029483"
     description: "ET MALWARE Win32/AZORult V3.3 Client Checkin M17"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).{6,43}(?-i:p�G\u0016�0d�E\u0011�\\&f�Bp�G).*?(?-i:^(?:\\x00\\x00\\x00)?(?:[\\x40-\\x42]|[\\x45-\\x47]|\\x26\\x66))"
@@ -284959,8 +283371,7 @@ rules:
       to_server: true
   - name: "sid:2044379"
     description: "ET MALWARE ReverseRat 3.0 CnC Checkin M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:;���0�\\\r�J�)"
@@ -284970,8 +283381,7 @@ rules:
       to_server: true
   - name: "sid:2044380"
     description: "ET MALWARE ReverseRat 3.0 CnC Checkin M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:b�ЏѴ\u0016l\\\u000b6)"
@@ -287144,8 +285554,7 @@ rules:
       to_server: true
   - name: "sid:2050874"
     description: "ET MALWARE Pikabot Related Activity M5 (POST)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     dst_port:
       ports: []
@@ -288720,8 +287129,7 @@ rules:
       to_server: true
   - name: "sid:2034084"
     description: "ET MALWARE Cobalt Strike Malleable C2 Amazon Profile POST (JPEG)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:/s/ref=nb_sb_noss_1/167\\-3294888\\-0262949/field\\-keywords=books).*?(?-i:���)"
@@ -288731,8 +287139,7 @@ rules:
       to_server: true
   - name: "sid:2034085"
     description: "ET MALWARE Cobalt Strike Malleable C2 Amazon Profile POST (PNG)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:/s/ref=nb_sb_noss_1/167\\-3294888\\-0262949/field\\-keywords=books).*?(?-i:�PNG)"
@@ -289859,8 +288266,7 @@ rules:
       to_server: true
   - name: "sid:2024659"
     description: "ET MALWARE [PTsecurity] Tinba Checkin 4"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?i:content\\-length:\\ 157).*?(?-i:\u0000�\u0000\u0000\u0000)"
@@ -290331,8 +288737,7 @@ rules:
       to_server: true
   - name: "sid:2030913"
     description: "ET MALWARE FinSpy Related WinRAR Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:\\.php\\?attachmentid=).{0,}(?-i:\\&d=).*?(?-i:\\.��2\u001f6�\u0008��\u0019R�\\.�<)"
@@ -290342,8 +288747,7 @@ rules:
       to_server: true
   - name: "sid:2030914"
     description: "ET MALWARE FinSpy Related Flash Installer Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:\\.asp\\?attachmentid=).{0,}(?-i:\\&d=).*?(?-i:��!�wוa\\*'\"�\\*��\u0016)"
@@ -290403,8 +288807,7 @@ rules:
       to_server: true
   - name: "sid:2020821"
     description: "ET MALWARE Win32/Hyteod CnC Beacon"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:GET).*?(?-i:_\\^\\[��\\]).*?(?-i:Mozilla/5\\.0\\ \\(compatible;\\ MSIE\\ 9\\.0;\\ Windows\\ NT\\ 6\\.1;\\ Trident/5\\.0\\)).*?(?-i:application/x\\-www\\-form\\-urlencoded)"
@@ -292993,8 +291396,7 @@ rules:
       to_server: true
   - name: "sid:2029554"
     description: "ET USER_AGENTS Observed Suspicious UA (\\xa4)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\\\r\\\nuser\\-agent:\\ �\\\r\\\n).*?(?-i:�)"
@@ -293657,8 +292059,7 @@ rules:
       to_server: true
   - name: "sid:2017895"
     description: "ET MALWARE Kuluoz/Asprox Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:�\u0000\u0000\u0000).*?(?-i:^/(?:[A-Fa-f0-9]+|index\\.php)$)"
@@ -294922,8 +293323,7 @@ rules:
       to_server: true
   - name: "sid:2025923"
     description: "ET MALWARE Win32/Bisonal RC4 Encrypted 8 Byte Static CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:����\\~�\u001b�)"
@@ -296021,8 +294421,7 @@ rules:
       to_server: true
   - name: "sid:2029458"
     description: "ET MALWARE Win32/AZORult V3.2 Client Checkin M11"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:J).{10,49}(?-i:O�>\\?�>>�>>�\\(9�\\(9�\\(8�\\(9�).*?(?-i:^(?:[\\x4b-\\x4c]|[\\x48-\\x49]|[\\x4e-\\x4f]|\\x2f\\xfb))"
@@ -296032,8 +294431,7 @@ rules:
       to_server: true
   - name: "sid:2034050"
     description: "ET MALWARE Win32/AZORult V3.2 Client Checkin M22"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:J).{10,45}(?-i:\\(9�\\(9�\\(9�LH�\\(9�\\(8�O).*?(?-i:^(?:[\\x4b-\\x4c]|[\\x48-\\x49]|[\\x4e-\\x4f]|\\x2f\\xfb))"
@@ -296043,8 +294441,7 @@ rules:
       to_server: true
   - name: "sid:2029464"
     description: "ET MALWARE Win32/AZORult V3.2 Client Checkin M14"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:J).{10,51}(?-i:/�4/�9/�</�9/�4/�=/�:/�IK).*?(?-i:^(?:[\\x4b-\\x4c]|[\\x48-\\x49]|[\\x4e-\\x4f]|\\x2f\\xfb))"
@@ -296054,8 +294451,7 @@ rules:
       to_server: true
   - name: "sid:2034052"
     description: "ET MALWARE Win32/AZORult V3.2 Client Checkin M24"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:J).{10,45}(?-i:�>8�>9�>;�OO�><�\\?N�).*?(?-i:^(?:[\\x4b-\\x4c]|[\\x48-\\x49]|[\\x4e-\\x4f]|\\x2f\\xfb))"
@@ -296065,8 +294461,7 @@ rules:
       to_server: true
   - name: "sid:2029457"
     description: "ET MALWARE Win32/AZORult V3.2 Client Checkin M10"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:J).{10,49}(?-i:H/�8/�9/�9H�>\\?�>=�\\?N�>>).*?(?-i:^(?:[\\x4b-\\x4c]|[\\x48-\\x49]|[\\x4e-\\x4f]|\\x2f\\xfb))"
@@ -296076,8 +294471,7 @@ rules:
       to_server: true
   - name: "sid:2029485"
     description: "ET MALWARE Win32/AZORult V3.2 Client Checkin M19"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:J).{10,47}(?-i:ON�>:�>2�>>�>>�><�\\?N�).*?(?-i:^(?:[\\x4b-\\x4c]|[\\x48-\\x49]|[\\x4e-\\x4f]|\\x2f\\xfb))"
@@ -296087,8 +294481,7 @@ rules:
       to_server: true
   - name: "sid:2029479"
     description: "ET MALWARE Win32/AZORult V3.2 Client Checkin M16"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:J).{10,41}(?-i:N/�<K�IH�>:�\\?N�).*?(?-i:^(?:[\\x4b-\\x4c]|[\\x48-\\x49]|[\\x4e-\\x4f]|\\x2f\\xfb))"
@@ -296098,8 +294491,7 @@ rules:
       to_server: true
   - name: "sid:2029465"
     description: "ET MALWARE Win32/AZORult V3.2 Client Checkin M15"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:J).{10,51}(?-i:�>3�>>�>;�>>�>3�>:�>=�\\?N�).*?(?-i:^(?:[\\x4b-\\x4c]|[\\x48-\\x49]|[\\x4e-\\x4f]|\\x2f\\xfb))"
@@ -296109,8 +294501,7 @@ rules:
       to_server: true
   - name: "sid:2029463"
     description: "ET MALWARE Win32/AZORult V3.2 Client Checkin M13"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:J).{10,51}(?-i:\\(9�\\(9�\\(9�\\(9�\\(9�\\(9�\\(9�\\(8�L).*?(?-i:^(?:[\\x4b-\\x4c]|[\\x48-\\x49]|[\\x4e-\\x4f]|\\x2f\\xfb))"
@@ -296120,8 +294511,7 @@ rules:
       to_server: true
   - name: "sid:2029437"
     description: "ET MALWARE Win32/AZORult V3.2 Client Checkin M5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:J).{10,45}(?-i:/�5/�;I�>9�KI�\\?N�>=).*?(?-i:^(?:[\\x4b-\\x4c]|[\\x48-\\x49]|[\\x4e-\\x4f]|\\x2f\\xfb))"
@@ -296131,8 +294521,7 @@ rules:
       to_server: true
   - name: "sid:2029438"
     description: "ET MALWARE Win32/AZORult V3.2 Client Checkin M6"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:J).{10,45}(?-i:�>2�><�\\(9�IL�\\(8�\\(9�).*?(?-i:^(?:[\\x4b-\\x4c]|[\\x48-\\x49]|[\\x4e-\\x4f]|\\x2f\\xfb))"
@@ -296142,8 +294531,7 @@ rules:
       to_server: true
   - name: "sid:2029480"
     description: "ET MALWARE Win32/AZORult V3.2 Client Checkin M17"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:J).{10,41}(?-i:I�>;�KN�\\(9�\\(8�L).*?(?-i:^(?:[\\x4b-\\x4c]|[\\x48-\\x49]|[\\x4e-\\x4f]|\\x2f\\xfb))"
@@ -296153,8 +294541,7 @@ rules:
       to_server: true
   - name: "sid:2029443"
     description: "ET MALWARE Win32/AZORult V3.2 Client Checkin M8"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:J).{10,47}(?-i:/�:/�\\?N�><�>=�>3�\\(8�O).*?(?-i:^(?:[\\x4b-\\x4c]|[\\x48-\\x49]|[\\x4e-\\x4f]|\\x2f\\xfb))"
@@ -296164,8 +294551,7 @@ rules:
       to_server: true
   - name: "sid:2029402"
     description: "ET MALWARE Win32/AZORult V3.2 Client Checkin M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:J).{10,47}(?-i:/�>/�9/�>K�>8�N/�I/�;).*?(?-i:^(?:[\\x4b-\\x4c]|[\\x48-\\x49]|[\\x4e-\\x4f]|\\x2f\\xfb))"
@@ -296175,8 +294561,7 @@ rules:
       to_server: true
   - name: "sid:2029481"
     description: "ET MALWARE Win32/AZORult V3.2 Client Checkin M18"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:J).{10,41}(?-i:�\\(9�LL�O/�=/�IK).*?(?-i:^(?:[\\x4b-\\x4c]|[\\x48-\\x49]|[\\x4e-\\x4f]|\\x2f\\xfb))"
@@ -296186,8 +294571,7 @@ rules:
       to_server: true
   - name: "sid:2034051"
     description: "ET MALWARE Win32/AZORult V3.2 Client Checkin M23"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:J).{10,45}(?-i:/�\\?/�>/�<K�H/�;/�IH).*?(?-i:^(?:[\\x4b-\\x4c]|[\\x48-\\x49]|[\\x4e-\\x4f]|\\x2f\\xfb))"
@@ -296197,8 +294581,7 @@ rules:
       to_server: true
   - name: "sid:2029487"
     description: "ET MALWARE Win32/AZORult V3.2 Client Checkin M21"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:J).{10,47}(?-i:�I/�=/�5/�9/�9/�;/�IH).*?(?-i:^(?:[\\x4b-\\x4c]|[\\x48-\\x49]|[\\x4e-\\x4f]|\\x2f\\xfb))"
@@ -296208,8 +294591,7 @@ rules:
       to_server: true
   - name: "sid:2029486"
     description: "ET MALWARE Win32/AZORult V3.2 Client Checkin M20"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:J).{10,47}(?-i:H�\\(9�\\(9�\\(9�\\(9�\\(9�\\(8�O).*?(?-i:^(?:[\\x4b-\\x4c]|[\\x48-\\x49]|[\\x4e-\\x4f]|\\x2f\\xfb))"
@@ -296219,8 +294601,7 @@ rules:
       to_server: true
   - name: "sid:2029442"
     description: "ET MALWARE Win32/AZORult V3.2 Client Checkin M7"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:J).{10,47}(?-i:\\(9�\\(9�I/�;/�:/�4H�\\?N�).*?(?-i:^(?:[\\x4b-\\x4c]|[\\x48-\\x49]|[\\x4e-\\x4f]|\\x2f\\xfb))"
@@ -296230,8 +294611,7 @@ rules:
       to_server: true
   - name: "sid:2029459"
     description: "ET MALWARE Win32/AZORult V3.2 Client Checkin M12"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:J).{10,49}(?-i:�\\(9�\\(9�\\(9�O/�8/�:/�I/�9).*?(?-i:^(?:[\\x4b-\\x4c]|[\\x48-\\x49]|[\\x4e-\\x4f]|\\x2f\\xfb))"
@@ -296241,8 +294621,7 @@ rules:
       to_server: true
   - name: "sid:2029401"
     description: "ET MALWARE Win32/AZORult V3.2 Client Checkin M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:J).{10,47}(?-i:\\(9�\\(9�\\(9�L/�\\?O�\\(8�\\(9�).*?(?-i:^(?:[\\x4b-\\x4c]|[\\x48-\\x49]|[\\x4e-\\x4f]|\\x2f\\xfb))"
@@ -296252,8 +294631,7 @@ rules:
       to_server: true
   - name: "sid:2029436"
     description: "ET MALWARE Win32/AZORult V3.2 Client Checkin M4"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:J).{10,45}(?-i:\\(9�\\(9�N/�>N�N/�I/�:).*?(?-i:^(?:[\\x4b-\\x4c]|[\\x48-\\x49]|[\\x4e-\\x4f]|\\x2f\\xfb))"
@@ -296263,8 +294641,7 @@ rules:
       to_server: true
   - name: "sid:2029444"
     description: "ET MALWARE Win32/AZORult V3.2 Client Checkin M9"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:J).{10,47}(?-i:�>=�>8�\\(9�\\(9�\\(9�O/�IH).*?(?-i:^(?:[\\x4b-\\x4c]|[\\x48-\\x49]|[\\x4e-\\x4f]|\\x2f\\xfb))"
@@ -296443,8 +294820,7 @@ rules:
       to_server: true
   - name: "sid:2013819"
     description: "ET MALWARE Tatanga/Win32.Kexject.A Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?i:POST).*?(?-i:\\.php).*?(?-i:����\u0003\u0000)"
@@ -296857,8 +295233,7 @@ rules:
       to_server: true
   - name: "sid:2024637"
     description: "ET MALWARE Gazer HTTP POST Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:\\.php\\?).*?(?-i:����\u0000\u0000\u0000\u0000).*?(?i:^(?:(?:a(?:(?:lbu|d)m|ccount|uthor)|c(?:ont(?:ac|en)|lien)t|p(?:artners|hoto)|(?:memb|us)er|session|video|hash|key|id)=[a-z0-9]{6,12}&){4})"
@@ -297152,8 +295527,7 @@ rules:
       to_server: true
   - name: "sid:2024771"
     description: "ET MALWARE [PTsecurity] Possible Cobalt Strike payload"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:��\u0000\u0000\u0000\u0000�)"
@@ -301898,8 +300272,7 @@ rules:
       to_server: true
   - name: "sid:2052876"
     description: "ET MALWARE Unknown RAT CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -303245,8 +301618,7 @@ rules:
       to_client: true
   - name: "sid:2050707"
     description: "ET REMOTE_ACCESS AnyDesk Revoked Code Signing Certificate Observed"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -303267,8 +301639,7 @@ rules:
       to_server: true
   - name: "sid:2027192"
     description: "ET REMOTE_ACCESS Tunneled RDP msts Handshake"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -303281,8 +301652,7 @@ rules:
       max: 64
   - name: "sid:2027193"
     description: "ET REMOTE_ACCESS Tunneled RDP Handshake"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -303295,8 +301665,7 @@ rules:
       established: true
   - name: "sid:2027412"
     description: "ET REMOTE_ACCESS Inbound RDP Connection with TLS Security Protocol Requested"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -303312,8 +301681,7 @@ rules:
       to_server: true
   - name: "sid:2027413"
     description: "ET REMOTE_ACCESS Inbound RDP Connection with Minimal Security Protocol Requested"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -303327,8 +301695,7 @@ rules:
       to_server: true
   - name: "sid:2048143"
     description: "ET REMOTE_ACCESS ScreenConnect/ConnectWise Initial Checkin Packet M3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -303338,8 +301705,7 @@ rules:
       max: 599
   - name: "sid:2036627"
     description: "ET REMOTE_ACCESS ScreenConnect/ConnectWise Initial Checkin Packet M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -303349,8 +301715,7 @@ rules:
       max: 599
   - name: "sid:2048051"
     description: "ET REMOTE_ACCESS ScreenConnect/ConnectWise Initial Checkin Packet M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -303420,8 +301785,7 @@ rules:
       to_client: true
   - name: "sid:2053438"
     description: "ET PHISHING UEFA EURO 2024 Survey Landing Page 2024-06-11"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:200).*?(?-i:UEFA\\ EURO\\ 2024\\ Mystery\\ Box).*?(?-i:enqu�te)"
@@ -336336,8 +334700,7 @@ rules:
       to_server: true
   - name: "sid:2034092"
     description: "ET FILE_SHARING File Sharing Wizard 1.5.0 - SEH Overflow Inbound (CVE-2019-16724)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -338055,8 +336418,7 @@ rules:
       to_client: true
   - name: "sid:2022115"
     description: "ET INFO Serialized Java Object Calling Common Collection Function"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -340586,8 +338948,7 @@ rules:
       case_insensitive: false
   - name: "sid:2012709"
     description: "ET REMOTE_ACCESS MS Remote Desktop Administrator Login Request"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -340601,8 +338962,7 @@ rules:
       to_server: true
   - name: "sid:2012710"
     description: "ET REMOTE_ACCESS MS Terminal Server Root login"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -341076,8 +339436,7 @@ rules:
       case_insensitive: false
   - name: "sid:2054103"
     description: "ET MALWARE JS/UnkRAT RC4 Encrypted Payload Inbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�L��w6�j��/\u0003��\u0012�\u001bI��7�\\ �f�A�)"
@@ -341087,8 +339446,7 @@ rules:
       to_client: true
   - name: "sid:2054104"
     description: "ET MALWARE Koadic RC4 Encrypted Payload Inbound M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�\\\r��j\\#��%�z\\&��\u001f�\u0016I�6�e�;�@)"
@@ -341546,8 +339904,7 @@ rules:
       to_server: true
   - name: "sid:2023349"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 106"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -341560,8 +339917,7 @@ rules:
       to_server: true
   - name: "sid:2034977"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 109"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -341574,8 +339930,7 @@ rules:
       to_server: true
   - name: "sid:2022773"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 105"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -341588,8 +339943,7 @@ rules:
       to_server: true
   - name: "sid:2022401"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 104"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -341621,8 +339975,7 @@ rules:
       to_server: true
   - name: "sid:2021753"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 103"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -341635,8 +339988,7 @@ rules:
       to_server: true
   - name: "sid:2021716"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 102"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -341649,8 +340001,7 @@ rules:
       to_server: true
   - name: "sid:2021065"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 101"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -341663,8 +340014,7 @@ rules:
       to_server: true
   - name: "sid:2021012"
     description: "ET MALWARE Backdoor family PCRat/Gh0st CnC traffic (OUTBOUND) 100"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -342900,8 +341250,7 @@ rules:
       to_server: true
   - name: "sid:2054419"
     description: "ET MALWARE [ANY.RUN] MetaStealer v.5 (MC-NMF TLS Server Certificate)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -343131,8 +341480,7 @@ rules:
       to_server: true
   - name: "sid:2052457"
     description: "ET MALWARE GhostRat CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -343625,8 +341973,7 @@ rules:
       to_server: true
   - name: "sid:2054620"
     description: "ET MALWARE Win32/Kryptik_AGen.DOP C2 Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -344423,8 +342770,7 @@ rules:
       to_server: true
   - name: "sid:2055003"
     description: "ET MALWARE DeerStealer CnC Activity M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:Keep\\-Alive).*?(?-i:\\\r\\\npid\\\r\\\n).*?(?-i:\\*/\\*).*?(?-i:����\u0000\u0000\u0000\u0000\u0003\u0000\u0000\u0000\u0000\u0000\u0000\u0000)"
@@ -344434,8 +342780,7 @@ rules:
       to_server: true
   - name: "sid:2055004"
     description: "ET MALWARE DeerStealer CnC Activity M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:Keep\\-Alive).*?(?-i:\\\r\\\npid\\\r\\\n).*?(?-i:\\*/\\*).*?(?-i:\u0003\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000����).*?(?-i:����������������)"
@@ -345222,8 +343567,7 @@ rules:
       to_client: true
   - name: "sid:2055309"
     description: "ET EXPLOIT OpenBMC slpd-lite Language Tag Length Memory Corruption Attempt (CVE-2024-41660)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -346296,8 +344640,7 @@ rules:
         flag: "ET.CVE-2024-38063"
   - name: "sid:2055645"
     description: "ET HUNTING Byte-order mark UTF-16LE (little endian)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:��)"
@@ -346311,8 +344654,7 @@ rules:
     private: true
   - name: "sid:2055646"
     description: "ET HUNTING Byte-order mark UTF-16BE (big endian)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:��)"
@@ -346326,8 +344668,7 @@ rules:
     private: true
   - name: "sid:2055647"
     description: "ET HUNTING Byte-order mark UTF-32LE (little endian)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:��\u0000\u0000)"
@@ -346341,8 +344682,7 @@ rules:
     private: true
   - name: "sid:2055648"
     description: "ET HUNTING Byte-order mark UTF-32BE (big endian)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000��)"
@@ -346370,8 +344710,7 @@ rules:
     private: true
   - name: "sid:2055650"
     description: "ET HUNTING Byte-order mark UTF-1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�dL)"
@@ -346385,8 +344724,7 @@ rules:
     private: true
   - name: "sid:2055651"
     description: "ET HUNTING Byte-order mark UTF-EBCDIC"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�sfs)"
@@ -346863,8 +345201,7 @@ rules:
       to_server: true
   - name: "sid:2036541"
     description: "ET RETIRED Eternity Stealer Screen Capture Activity"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     domain:
       domains: ["city="]
@@ -348227,8 +346564,7 @@ rules:
       to_server: true
   - name: "sid:2038664"
     description: "ET RETIRED Win32/Caypnamer.A RAT CnC Initial Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -350997,8 +349333,7 @@ rules:
       to_server: true
   - name: "sid:2044449"
     description: "ET RETIRED Parallax CnC Activity M18 (set)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -351013,8 +349348,7 @@ rules:
     private: true
   - name: "sid:2044450"
     description: "ET RETIRED Parallax CnC Response Activity M18"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -352501,8 +350835,7 @@ rules:
       to_server: true
   - name: "sid:2056539"
     description: "ET MALWARE Havoc Demon CnC Request"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:ޭ��).{4}(?-i:\u0000\u0000\u0000c)"
@@ -352529,8 +350862,7 @@ rules:
       to_server: true
   - name: "sid:2056550"
     description: "ET MALWARE Win32/DeerStealer CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:\\\r\\\nConnection\\\r\\\nAccept\\\r\\\nUser\\-Agent\\\r\\\nContent\\-Length\\\r\\\nHost\\\r\\\n\\\r\\\n).*?(?-i:������\\$).*?(?-i:^.+\\x3f[a-zA-Z0-9]{8,20}\\x3d[a-zA-Z0-9+\\x2f=]{30,200}$).*?(?-i:^[a-f0-9]{8}-(?:[a-f0-9]{4}-){3}[a-f0-9]{12})"
@@ -352953,8 +351285,7 @@ rules:
       to_client: true
   - name: "sid:2056645"
     description: "ET MALWARE Suspected PrivateLoader CnC Checkin - Server Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -353340,8 +351671,7 @@ rules:
       to_server: true
   - name: "sid:2056726"
     description: "ET MALWARE BumbleBee Loader CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -353352,8 +351682,7 @@ rules:
       to_server: true
   - name: "sid:2056727"
     description: "ET MALWARE BumbleBee Loader CnC Server Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -353404,8 +351733,7 @@ rules:
       to_server: true
   - name: "sid:2056730"
     description: "ET EXPLOIT Fortinet FGFM Arbitrary Code Execution via Externally-Controlled Format String (CVE-2024-23113)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -356043,8 +354371,7 @@ rules:
       to_server: true
   - name: "sid:2057196"
     description: "ET MALWARE Win32/BlackShadow Activity (GET) M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:/register).*?(?-i:\\&a�!\\&\u0003\u0000\u0000)"
@@ -356064,8 +354391,7 @@ rules:
       to_server: true
   - name: "sid:2057160"
     description: "ET MALWARE Win32/BugSleep CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -356222,8 +354548,7 @@ rules:
       to_client: true
   - name: "sid:2057247"
     description: "ET MALWARE [NCSC] Pygmy Goat SSH ed25519 Key"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,120}(?-i:\\)���\u0016�FnR\u0019���eB�\u001f\u001a�å����\\&l1<\\\\�:\\$\\}��Wmڎ��f�ˁOc�J�\u0006�\\~L����˗��\u000f)"
@@ -358378,8 +356703,7 @@ rules:
       to_client: true
   - name: "sid:2057690"
     description: "ET EXPLOIT Fortinet FortiManager Unauthenticated Get File Transfer Handle"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -358396,8 +356720,7 @@ rules:
         flag: "ET.FMFG_CVE-2024-47575"
   - name: "sid:2057691"
     description: "ET EXPLOIT Fortinet FortiManager File Transfer Handle Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -358414,8 +356737,7 @@ rules:
         flag: "ET.FMFG_CVE-2024-47575"
   - name: "sid:2057692"
     description: "ET EXPLOIT Fortinet FortiManager Unauthenticated Remote Code Execution (CVE-2024-47575) M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -358429,8 +356751,7 @@ rules:
       to_server: true
   - name: "sid:2057693"
     description: "ET EXPLOIT Fortinet FortiManager Unauthenticated Open Server-Side Channel"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -358447,8 +356768,7 @@ rules:
         flag: "ET.FMFG_CVE-2024-47575"
   - name: "sid:2057694"
     description: "ET EXPLOIT Fortinet FortiManager Unauthenticated Remote Code Execution (CVE-2024-47575) M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -360109,8 +358429,7 @@ rules:
       to_server: true
   - name: "sid:2102007"
     description: "GPL RPC kcms_server directory traversal attempt"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -375861,8 +374180,7 @@ rules:
       to_server: true
   - name: "sid:2012957"
     description: "ET RETIRED Backdoor.Win32.ZZSlash/Redosdru.E checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -375907,8 +374225,7 @@ rules:
       to_server: true
   - name: "sid:2013338"
     description: "ET RETIRED Bifrose Client Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -376163,8 +374480,7 @@ rules:
       to_server: true
   - name: "sid:2013337"
     description: "ET RETIRED PoisonIvy.E Keepalive to CnC"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -376177,8 +374493,7 @@ rules:
       to_server: true
   - name: "sid:2014143"
     description: "ET RETIRED PoisonIvy.Esf Keepalive to CnC"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -376191,8 +374506,7 @@ rules:
       to_server: true
   - name: "sid:2014144"
     description: "ET RETIRED PoisonIvy.Eks Keepalive to CnC"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -376205,8 +374519,7 @@ rules:
       to_server: true
   - name: "sid:2017361"
     description: "ET RETIRED PoisonIvy.fishplay Keepalive to CnC"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -376219,8 +374532,7 @@ rules:
       to_server: true
   - name: "sid:2019591"
     description: "ET RETIRED PoisonIvy Keepalive to CnC (Operation SMN Variant)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -376955,192 +375267,168 @@ rules:
       to_client: true
   - name: "sid:2026920"
     description: "ET ATTACK_RESPONSE PowerShell Execution String Base64 Encoded New-Object (V3LU9) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:V3LU9)"
       case_insensitive: false
   - name: "sid:2026921"
     description: "ET ATTACK_RESPONSE PowerShell Execution String Base64 Encoded New-Object (ctT2J) in DNS TXT Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:ctT2J)"
       case_insensitive: false
   - name: "sid:2026922"
     description: "ET ATTACK_RESPONSE PowerShell Execution String Base64 Encoded New-Object (dy1PYmp) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:dy1PYmp)"
       case_insensitive: false
   - name: "sid:2026923"
     description: "ET ATTACK_RESPONSE PowerShell Execution String Base64 Encoded New-Object (V3LU9iam) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:V3LU9iam)"
       case_insensitive: false
   - name: "sid:2026924"
     description: "ET ATTACK_RESPONSE PowerShell Execution String Base64 Encoded New-Object (XctT2JqZW) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:XctT2JqZW)"
       case_insensitive: false
   - name: "sid:2026925"
     description: "ET ATTACK_RESPONSE PowerShell Execution String Base64 Encoded New-Object (dy1PYmplY3) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:dy1PYmplY3)"
       case_insensitive: false
   - name: "sid:2026926"
     description: "ET ATTACK_RESPONSE PowerShell Execution String Base64 Encoded Start-Process (FydC1Qcm9) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:FydC1Qcm9)"
       case_insensitive: false
   - name: "sid:2026927"
     description: "ET ATTACK_RESPONSE PowerShell Execution String Base64 Encoded Start-Process (RhcnQtUHJ) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:RhcnQtUHJ)"
       case_insensitive: false
   - name: "sid:2026928"
     description: "ET ATTACK_RESPONSE PowerShell Execution String Base64 Encoded Start-Process (YXJ0LVByb2N) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:YXJ0LVByb2N)"
       case_insensitive: false
   - name: "sid:2026929"
     description: "ET ATTACK_RESPONSE PowerShell Execution String Base64 Encoded Start-Process (RhcnQtUHJvY2) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:RhcnQtUHJvY2)"
       case_insensitive: false
   - name: "sid:2026930"
     description: "ET ATTACK_RESPONSE PowerShell Execution String Base64 Encoded Start-Process (GFydC1Qcm9jZX) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:GFydC1Qcm9jZX)"
       case_insensitive: false
   - name: "sid:2026931"
     description: "ET ATTACK_RESPONSE PowerShell Execution String Base64 Encoded Start-Process (YXJ0LVByb2Nlc3) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:YXJ0LVByb2Nlc3)"
       case_insensitive: false
   - name: "sid:2026932"
     description: "ET ATTACK_RESPONSE PowerShell Execution String Base64 Encoded Invoke-WmiMethod (Zva2UtV21pTWV) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:Zva2UtV21pTWV)"
       case_insensitive: false
   - name: "sid:2026933"
     description: "ET ATTACK_RESPONSE PowerShell Execution String Base64 Encoded Invoke-WmiMethod (52b2tlLVdtaU1) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:52b2tlLVdtaU1)"
       case_insensitive: false
   - name: "sid:2026934"
     description: "ET ATTACK_RESPONSE PowerShell Execution String Base64 Encoded Invoke-WmiMethod (dm9rZS1XbWlNZXR) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:dm9rZS1XbWlNZXR)"
       case_insensitive: false
   - name: "sid:2026935"
     description: "ET ATTACK_RESPONSE PowerShell Execution String Base64 Encoded Invoke-WmiMethod (52b2tlLVdtaU1ldG) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:52b2tlLVdtaU1ldG)"
       case_insensitive: false
   - name: "sid:2026936"
     description: "ET ATTACK_RESPONSE PowerShell Execution String Base64 Encoded Invoke-WmiMethod (nZva2UtV21pTWV0aG) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:nZva2UtV21pTWV0aG)"
       case_insensitive: false
   - name: "sid:2026937"
     description: "ET ATTACK_RESPONSE PowerShell Execution String Base64 Encoded Invoke-WmiMethod (dm9rZS1XbWlNZXRob2) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:dm9rZS1XbWlNZXRob2)"
       case_insensitive: false
   - name: "sid:2026938"
     description: "ET ATTACK_RESPONSE PowerShell Execution String Base64 Encoded Invoke-Command (Zva2UtQ29) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:Zva2UtQ29)"
       case_insensitive: false
   - name: "sid:2026939"
     description: "ET ATTACK_RESPONSE PowerShell Execution String Base64 Encoded Invoke-Command (dm9rZS1Db21) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:dm9rZS1Db21)"
       case_insensitive: false
   - name: "sid:2026940"
     description: "ET ATTACK_RESPONSE PowerShell Execution String Base64 Encoded Invoke-Command (nZva2UtQ29tbW) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:nZva2UtQ29tbW)"
       case_insensitive: false
   - name: "sid:2026941"
     description: "ET ATTACK_RESPONSE PowerShell Execution String Base64 Encoded Invoke-Command (52b2tlLUNvbW1) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:52b2tlLUNvbW1)"
       case_insensitive: false
   - name: "sid:2026942"
     description: "ET ATTACK_RESPONSE PowerShell Execution String Base64 Encoded Invoke-Command (dm9rZS1Db21tYW) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:dm9rZS1Db21tYW)"
       case_insensitive: false
   - name: "sid:2026943"
     description: "ET ATTACK_RESPONSE PowerShell Execution String Base64 Encoded Invoke-Command (52b2tlLUNvbW1hbm) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:52b2tlLUNvbW1hbm)"
@@ -377208,48 +375496,42 @@ rules:
       to_server: true
   - name: "sid:2043161"
     description: "ET ATTACK_RESPONSE PowerShell String Base64 Encoded Invoke-RestMethod (dm9rZS1SZXN0TWV0) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:dm9rZS1SZXN0TWV0)"
       case_insensitive: false
   - name: "sid:2043162"
     description: "ET ATTACK_RESPONSE PowerShell String Base64 Encoded Invoke-RestMethod (Zva2UtUmVzdE1ld) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:Zva2UtUmVzdE1ld)"
       case_insensitive: false
   - name: "sid:2043163"
     description: "ET ATTACK_RESPONSE PowerShell String Base64 Encoded Invoke-RestMethod (2b2tlLVJlc3RNZX) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:2b2tlLVJlc3RNZX)"
       case_insensitive: false
   - name: "sid:2043164"
     description: "ET ATTACK_RESPONSE PowerShell String Base64 Encoded Text.Encoding (ZXh0LkVuY29k) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:ZXh0LkVuY29k)"
       case_insensitive: false
   - name: "sid:2043165"
     description: "ET ATTACK_RESPONSE PowerShell String Base64 Encoded Text.Encoding (V4dC5FbmNvZ) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:V4dC5FbmNvZ)"
       case_insensitive: false
   - name: "sid:2043166"
     description: "ET ATTACK_RESPONSE PowerShell String Base64 Encoded Text.Encoding (leHQuRW5jb2) in DNS TXT Reponse"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u0000\u0000\u0010\u0000\u0001�\\\u000c\u0000\u0010\u0000\u0001).{0,}(?-i:leHQuRW5jb2)"
@@ -377582,8 +375864,7 @@ rules:
       to_server: true
   - name: "sid:2058238"
     description: "ET MALWARE XiebroC2 CnC Activity KeepAlive M1 (Outbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -377596,8 +375877,7 @@ rules:
       to_server: true
   - name: "sid:2058239"
     description: "ET MALWARE XiebroC2 CnC Activity KeepAlive M2 (Outbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -377610,8 +375890,7 @@ rules:
       to_server: true
   - name: "sid:2058240"
     description: "ET MALWARE XiebroC2 CnC Activity KeepAlive M3 (Outbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -377624,8 +375903,7 @@ rules:
       to_server: true
   - name: "sid:2058241"
     description: "ET MALWARE XiebroC2 CnC Activity KeepAlive M1 (Inbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -377638,8 +375916,7 @@ rules:
       to_server: true
   - name: "sid:2058242"
     description: "ET MALWARE XiebroC2 CnC Activity KeepAlive M2 (Inbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -377652,8 +375929,7 @@ rules:
       to_server: true
   - name: "sid:2058243"
     description: "ET MALWARE XiebroC2 CnC Activity KeepAlive M3 (Inbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -377666,8 +375942,7 @@ rules:
       to_server: true
   - name: "sid:2058244"
     description: "ET MALWARE XiebroC2 CnC Activity SendInfo M1 (Outbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -377680,8 +375955,7 @@ rules:
       to_server: true
   - name: "sid:2058245"
     description: "ET MALWARE XiebroC2 CnC Activity SendInfo M2 (Outbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -377692,8 +375966,7 @@ rules:
       to_server: true
   - name: "sid:2058246"
     description: "ET MALWARE XiebroC2 CnC Activity SendInfo M3 (Outbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -377706,8 +375979,7 @@ rules:
       to_server: true
   - name: "sid:2058247"
     description: "ET MALWARE XiebroC2 CnC Activity, Disconnect M1 (Outbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -377720,8 +375992,7 @@ rules:
       to_server: true
   - name: "sid:2058248"
     description: "ET MALWARE XiebroC2 CnC Activity Disconnect M2 (Outbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -377734,8 +376005,7 @@ rules:
       to_server: true
   - name: "sid:2058249"
     description: "ET MALWARE XiebroC2 CnC Activity, Disconnect M3 (Outbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -377748,8 +376018,7 @@ rules:
       to_server: true
   - name: "sid:2058250"
     description: "ET MALWARE XiebroC2 CnC Activity List Process M1 (Outbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -377762,8 +376031,7 @@ rules:
       to_server: true
   - name: "sid:2058251"
     description: "ET MALWARE XiebroC2 CnC Activity List Process M2 (Outbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -377776,8 +376044,7 @@ rules:
       to_server: true
   - name: "sid:2058252"
     description: "ET MALWARE XiebroC2 CnC Activity List Process M3 (Outbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -378712,8 +376979,7 @@ rules:
       to_server: true
   - name: "sid:2058332"
     description: "ET MALWARE XiebroC2 CnC Activity KeepAlive M4 (Outbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -378726,8 +376992,7 @@ rules:
       to_server: true
   - name: "sid:2058333"
     description: "ET MALWARE XiebroC2 CnC Activity KeepAlive M4 (Inbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -378740,8 +377005,7 @@ rules:
       to_server: true
   - name: "sid:2058334"
     description: "ET MALWARE XiebroC2 CnC Activity SendInfo M4 (Outbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -378754,8 +377018,7 @@ rules:
       to_server: true
   - name: "sid:2058335"
     description: "ET MALWARE XiebroC2 CnC Activity Disconnect M4 (Outbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -378768,8 +377031,7 @@ rules:
       to_server: true
   - name: "sid:2058336"
     description: "ET MALWARE XiebroC2 CnC Activity List Process M4 (Outbound)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -379411,8 +377673,7 @@ rules:
       to_server: true
   - name: "sid:2058410"
     description: "ET MALWARE Xenorat Default C2 Server Response Inbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -381918,8 +380179,7 @@ rules:
       to_server: true
   - name: "sid:2058707"
     description: "ET SCAN ELF/Mirai Variant UDP (Inbound) M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -381927,8 +380187,7 @@ rules:
       case_insensitive: false
   - name: "sid:2058708"
     description: "ET SCAN ELF/Mirai Variant UDP (Inbound) M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -384353,8 +382612,7 @@ rules:
       to_server: true
   - name: "sid:2058998"
     description: "ET MALWARE DcRAT/Sheet RAT CnC Checkin Using MessagePack"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -384518,8 +382776,7 @@ rules:
       to_server: true
   - name: "sid:2059017"
     description: "ET EXPLOIT Microsoft LDAP Referral Response Inbound (CVE-2024-49113)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -389301,8 +387558,7 @@ rules:
       to_server: true
   - name: "sid:2059664"
     description: "ET MALWARE Nosviak C2 Variant Host Status Page Response (sha1:7894a2cf11597ca5b3dcd8516294d2b06528d3fa)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:x���\u0011Y\\|����Qb�Ұe\\(��)"
@@ -389312,8 +387568,7 @@ rules:
       to_client: true
   - name: "sid:2059665"
     description: "ET MALWARE Nosviak C2 Variant Host Status Page Response (sha1:8b1ebc6832852a06ab02097af10c4984b557a957)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�\u001e�h2�\\*\u0006�\u0002\\\tz�\\\u000cI��W�W)"
@@ -389323,8 +387578,7 @@ rules:
       to_client: true
   - name: "sid:2059666"
     description: "ET MALWARE Nosviak C2 Variant Host Status Page Response (sha1:3e2561532be10aa91242c3867f3257f6a005b1b8)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:>%aS\\+�\\\n�\u0012BÆ\u007f2W��\u0005��)"
@@ -389344,8 +387598,7 @@ rules:
       to_client: true
   - name: "sid:2059668"
     description: "ET MALWARE SSN C2 Build Status Page Response (sha1:e9371aca7b792814d55df07b56a9aafd25ee3b89)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�7\u001a�\\{y\\(\u0014�\\]�\\{V���%�;�)"
@@ -389355,8 +387608,7 @@ rules:
       to_client: true
   - name: "sid:2059669"
     description: "ET MALWARE Moonly C2 API Management Page Response (sha1:c1a12dd0ac8283f60349f8800e5ac889d495b4cf)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:��\\-Ь���\u0003I��\u000eZȉԕ��)"
@@ -389366,8 +387618,7 @@ rules:
       to_client: true
   - name: "sid:2059670"
     description: "ET MALWARE Erf C2 Admin Panel Page Response (sha1:63060ac2fb64f9045b054bbdd8d73d4f6905b4f3)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:c\u0006\\\n��d�\u0004\\[\u0005K���=Oi\u0005��)"
@@ -389377,8 +387628,7 @@ rules:
       to_client: true
   - name: "sid:2059671"
     description: "ET MALWARE Erf C2 API Management Page Response (sha1:911936199d078877a5ccd93537471044251806ca)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:�\u00196\u0019�\u0007�w���57G\u0010D%\u0018\u0006�)"
@@ -391135,8 +389385,7 @@ rules:
       to_server: true
   - name: "sid:2059890"
     description: "ET WEB_SPECIFIC_APPS DrayTek Gateway Web Management Interface OS Command Injection (CVE-2024-12987)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:GET).*?(?-i:/cgi\\-bin/mainfunction\\.cgi/apmcfgupload).*?(?-i:session=).{0,}(?-i:�%52\\$c%52\\$c)"
@@ -395741,8 +393990,7 @@ rules:
       to_server: true
   - name: "sid:2059975"
     description: "ET MALWARE Winos4.0 Framework CnC Login Message CnC Server Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -398421,8 +396669,7 @@ rules:
       to_server: true
   - name: "sid:2060870"
     description: "ET MALWARE TINYSHELL impad Variant Encrypted Auth Token"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -398433,8 +396680,7 @@ rules:
       case_insensitive: false
   - name: "sid:2060871"
     description: "ET MALWARE TINYSHELL impad Variant Command Packet"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -398466,8 +396712,7 @@ rules:
         no_case: false
   - name: "sid:2060872"
     description: "ET MALWARE TINYSHELL irad Variant ICMP Inbound (uSarguuS62bKRA0J)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: icmp
     action: traffic_attack
     regex:
@@ -398475,8 +396720,7 @@ rules:
       case_insensitive: false
   - name: "sid:2060873"
     description: "ET MALWARE TINYSHELL irad Variant ICMP Inbound (1spCq0BMbJwCoeZn)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: icmp
     action: traffic_attack
     regex:
@@ -399031,8 +397275,7 @@ rules:
       to_server: true
   - name: "sid:2060950"
     description: "ET MALWARE Unknown Stealer Victim Profile Exfiltration (POST)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:/upload).*?(?-i:Content\\-Disposition:\\ form\\-data;\\ name=\"file\";\\ filename=\"SystemInfo_).{0,}(?-i:\\\n\\\r\\\n��C\u0000o\u0000m\u0000p\u0000u\u0000t\u0000e\u0000r\u0000\\ \u0000N\u0000a\u0000m\u0000e\u0000:)"
@@ -402263,8 +400506,7 @@ rules:
       to_server: true
   - name: "sid:2043273"
     description: "ET EXPLOIT SugarCRM PHP Shell Upload Attempt (CVE-2023-22952)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:/index\\.php).*?(?-i:PHPSESSID=).*?(?i:content\\-disposition:\\ form\\-data;\\ name=\"module\"\\\r\\\n\\\r\\\nemailtemplates\\\r\\\n).*?(?i:\\\r\\\ncontent\\-disposition:\\ form\\-data;\\ name=\"action\"\\\r\\\n\\\r\\\nattachfiles\\\r\\\n).{0,}(?-i:�PNG\\\r\\\n\u001a\\\n).{0,}(?-i:<\\?php).*?(?-i:^PHPSESSID\\x3d[0-9a-f]{8}\\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\\b[0-9a-f]{12}$)"
@@ -404197,8 +402439,7 @@ rules:
       to_server: true
   - name: "sid:2061601"
     description: "ET MALWARE zgRAT / PureLogs Stealer GZIP Exfiltration Outbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -404539,8 +402780,7 @@ rules:
       to_server: true
   - name: "sid:2061633"
     description: "ET MALWARE PureLogs Backdoor Server GZIP C2 Traffic"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -404551,8 +402791,7 @@ rules:
       to_client: true
   - name: "sid:2061634"
     description: "ET MALWARE PureLogs Backdoor Client GZIP C2 Traffic"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -405377,8 +403616,7 @@ rules:
       to_server: true
   - name: "sid:2046729"
     description: "ET RETIRED [ANY.RUN] Remcos RAT Checkin 861"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -405622,8 +403860,7 @@ rules:
       case_insensitive: false
   - name: "sid:2048118"
     description: "ET RETIRED Earth Lusca/SprySOCKS CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -405934,8 +404171,7 @@ rules:
       to_server: true
   - name: "sid:2050279"
     description: "ET RETIRED [ANY.RUN] ZharkBOT HTTP CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:GET).*?(?-i:\\?id=).*?(?-i:us=).*?(?-i:mn=).*?(?-i:os=Windows).*?(?-i:bld=).*?(?-i:�\\(Windows�NT�10\\.0;�Win64;�x64\\)�).*?(?-i:^[a-f0-9]{32}&)"
@@ -406700,8 +404936,7 @@ rules:
       case_insensitive: false
   - name: "sid:2061788"
     description: "ET WEB_SPECIFIC_APPS BentoML Unauthenticated Remote Command Execution via Insecure Deserialization (CVE-2025-27520)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:application/vnd\\.bentoml\\+pickle).*?(?-i:�\u0004�)"
@@ -406785,8 +405020,7 @@ rules:
       to_server: true
   - name: "sid:2061804"
     description: "ET MALWARE Interlock RAT CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -410851,8 +409085,7 @@ rules:
         flag: "ET.RATatouille.Connect"
   - name: "sid:2062284"
     description: "ET EXPLOIT D-Link HNAP - Request Remote Buffer Overflow M2 (CVE-2014-3936)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:/HNAP1/).*?(?-i:@\\\\�)"
@@ -411826,8 +410059,7 @@ rules:
         flag: "ET.Interlock"
   - name: "sid:2062408"
     description: "ET MALWARE Interlock RAT CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -413599,8 +411831,7 @@ rules:
       to_server: true
   - name: "sid:2063197"
     description: "ET HUNTING TA829 CnC Check-in With Unknown Identifier String"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:��\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000).*?(?-i:@exist).*?(?-i:^(?:(?:[A-Fa-f0-9]{2}\\-){5}[A-Fa-f0-9]{2}|[A-Fa-f0-9]{16}|[A-Fa-f0-9]{63,65})\\x40)"
@@ -413610,8 +411841,7 @@ rules:
       to_server: true
   - name: "sid:2063198"
     description: "ET MALWARE TA829 CnC Check-in - RDPE1 Variant"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:��\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000).*?(?-i:@exist).*?(?-i:@RDPE1@).*?(?-i:^(?:[A-Fa-f0-9]{2}\\-){5}[A-Fa-f0-9]{2}\\x40)"
@@ -413621,8 +411851,7 @@ rules:
       to_server: true
   - name: "sid:2063199"
     description: "ET MALWARE TA829 CnC Check-in - RUSTY Variant"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:��\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000).*?(?-i:@exist).*?(?-i:@RUSTY@).*?(?-i:^(?:[A-Fa-f0-9]{2}\\-){5}[A-Fa-f0-9]{2}\\x40)"
@@ -413632,8 +411861,7 @@ rules:
       to_server: true
   - name: "sid:2063200"
     description: "ET MALWARE TA829 CnC Check-in - VIVAT Variant"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:��\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000).*?(?-i:@exist).*?(?-i:@VIVAT@).*?(?-i:^(?:[A-Fa-f0-9]{2}\\-){5}[A-Fa-f0-9]{2}\\x40)"
@@ -413643,8 +411871,7 @@ rules:
       to_server: true
   - name: "sid:2063201"
     description: "ET MALWARE TA829 CnC Check-in - CMPN1 Variant"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:��\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000).*?(?-i:@exist).*?(?-i:@CMPN1@).*?(?-i:^[A-Fa-f0-9]{16}\\x40)"
@@ -413654,8 +411881,7 @@ rules:
       to_server: true
   - name: "sid:2063202"
     description: "ET MALWARE TA829 CnC Check-in - GAGA1 Variant"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:��\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000).*?(?-i:@exist).*?(?-i:@GAGA1@).*?(?-i:^[A-Fa-f0-9]{63,65}\\x40)"
@@ -413665,8 +411891,7 @@ rules:
       to_server: true
   - name: "sid:2063203"
     description: "ET MALWARE TA829 Requesting Next Stage"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:��\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000get_update_manager).*?(?-i:^(?:32|64)$)"
@@ -413676,8 +411901,7 @@ rules:
       to_server: true
   - name: "sid:2063204"
     description: "ET MALWARE TA829 Requesting Next Stage"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:POST).*?(?-i:��\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000get_module_test_msg_module)"
@@ -419142,8 +417366,7 @@ rules:
       to_server: true
   - name: "sid:2063279"
     description: "ET HUNTING ConnectWise ScreenConnect Revoked Code Signing Certificate M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -419154,8 +417377,7 @@ rules:
       to_client: true
   - name: "sid:2063280"
     description: "ET HUNTING ConnectWise ScreenConnect Revoked Code Signing Certificate M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -420545,8 +418767,7 @@ rules:
       to_server: true
   - name: "sid:2051806"
     description: "ET RETIRED TheMoon CnC Checkin"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -432711,8 +430932,7 @@ rules:
       to_server: true
   - name: "sid:2052875"
     description: "ET MALWARE Winos4.0 Framework CnC Login Message"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -433348,8 +431568,7 @@ rules:
       exact: 24
   - name: "sid:2065009"
     description: "ET MALWARE BPFDoor TCP Magic Packet (Inbound) M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -433362,8 +431581,7 @@ rules:
       to_server: true
   - name: "sid:2065010"
     description: "ET MALWARE BPFDoor TCP Magic Packet (Inbound) M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -433376,8 +431594,7 @@ rules:
       to_server: true
   - name: "sid:2065011"
     description: "ET MALWARE BPFDoor TCP Magic Packet (Inbound) M3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -433439,8 +431656,7 @@ rules:
       to_server: true
   - name: "sid:2065035"
     description: "ET ATTACK_RESPONSE Braodo Loader Inbound"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:��\\&cls\\\r\\\necho\\ ).*?(?-i:jnnbyzemecjolofzfiifopwbfynbtuwfplwyqyaxcyqhgfopfszizx)"
@@ -434845,8 +433061,7 @@ rules:
       to_server: true
   - name: "sid:2065198"
     description: "ET HUNTING Windows Shortcut Link Padded Whitespace in Command Line Arguments (ZDI-CAN-25373)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -435262,8 +433477,7 @@ rules:
       to_server: true
   - name: "sid:2065235"
     description: "ET INFO WatchGuard Fireware OS IKEv2 Unauthenticated Vulnerable Version Disclosure (CVE-2025-9242)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     src_port:
       ports: [500]
@@ -438760,8 +436974,7 @@ rules:
       to_server: true
   - name: "sid:2065684"
     description: "ET WEB_SPECIFIC_APPS Adobe Coldfusion BlazeDS Java Object Deserialization Remote Code Execution (CVE-2017-3066)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:/flex2gateway/amf).*?(?-i:application/x\\-amf).*?(?-i:\u0000\u0003\u0000\u0000\u0000\u0001\u0000\u0000\u0000\u0000����\u0011\\\n\u00073sun\\.rmi\\.server\\.UnicastRef).*?(?-i:POST)"
@@ -438831,8 +437044,7 @@ rules:
       case_insensitive: false
   - name: "sid:2065690"
     description: "ET EXPLOIT 7-Zip 7z File PPMd Properties Parsing Integer Underflow (CVE-2023-31102)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -443736,8 +441948,7 @@ rules:
       to_server: true
   - name: "sid:2066289"
     description: "ET WEB_SPECIFIC_APPS Zoho ManageEngine OpManager getObjectData Insecure Deserialization RCE (CVE-2023-31099)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:/servlet/com\\.me\\.opmanager\\.extranet\\.remote\\.communication\\.fw\\.fe\\.RegionalListener).*?(?-i:authkey:).*?(?-i:regionid:).*?(?-i:method:).*?(?-i:��\u0000\u0005).*?(?-i:\\$DataObject).{0,}(?-i:\u0000\u0000\u0000\u0018).{0,}(?-i:x).*?(?-i:\\x0d\\x0a[rR][eE][gG][iI][oO][nN][iI][dD]\\x3a\\s*(?P<reqid>[^\\x0d\\x0a]+).*regReqID.*?(?P=reqid)).*?(?-i:^[\\x9c\\xda])"
@@ -444361,8 +442572,7 @@ rules:
       to_client: true
   - name: "sid:2066356"
     description: "ET MALWARE CastleRAT Malware Outbound Handshake"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -444444,8 +442654,7 @@ rules:
       to_server: true
   - name: "sid:2066363"
     description: "ET MALWARE CastleRAT Malware Outbound Handshake M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -444458,8 +442667,7 @@ rules:
       to_server: true
   - name: "sid:2066364"
     description: "ET MALWARE CastleRAT Malware Outbound Handshake M3"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -444482,8 +442690,7 @@ rules:
       to_server: true
   - name: "sid:2066366"
     description: "ET MALWARE CastleRAT Malware Outbound Handshake M4"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -444496,8 +442703,7 @@ rules:
       to_server: true
   - name: "sid:2066367"
     description: "ET MALWARE CastleRAT Malware Outbound Handshake M5"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -444510,8 +442716,7 @@ rules:
       to_server: true
   - name: "sid:2066368"
     description: "ET MALWARE CastleRAT Malware Outbound Handshake M6"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -444524,8 +442729,7 @@ rules:
       to_server: true
   - name: "sid:2066369"
     description: "ET MALWARE CastleRAT Malware Outbound Handshake M7"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -444538,8 +442742,7 @@ rules:
       to_server: true
   - name: "sid:2066370"
     description: "ET MALWARE CastleRAT Malware Outbound Handshake M8"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -444552,8 +442755,7 @@ rules:
       to_server: true
   - name: "sid:2066371"
     description: "ET MALWARE CastleRAT Malware Outbound Handshake M9"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -445234,8 +443436,7 @@ rules:
       to_server: true
   - name: "sid:2066447"
     description: "ET EXPLOIT FreeBSD rtsold DNSSL Remote Code Execution (CVE-2025-14558)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:\u001f).*?(?-i:�\u0000).*?(?-i:^.{7,64}[\\x3b\\x26\\x60\\x7c\\x24])"
@@ -445680,8 +443881,7 @@ rules:
       to_server: true
   - name: "sid:2066500"
     description: "ET INFO MongoDB SASL Authentication Detected"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -445699,8 +443899,7 @@ rules:
     private: true
   - name: "sid:2066501"
     description: "ET EXPLOIT MongoDB Mongobleed Unauthenticated Memory Leak (CVE-2025-14847)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -447801,8 +446000,7 @@ rules:
       to_client: true
   - name: "sid:2066746"
     description: "ET EXPLOIT Fortinet FortiSIEM phMonitor Unauthenticated Argument Injection (CVE-2025-64155)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -448983,8 +447181,7 @@ rules:
       to_server: true
   - name: "sid:2030524"
     description: "ET INFO Possible NOP Sled Observed in Large DNS over TCP Packet M1"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -449000,8 +447197,7 @@ rules:
       to_server: true
   - name: "sid:2030525"
     description: "ET INFO Possible NOP Sled Observed in Large DNS over TCP Packet M2"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -450930,8 +449126,7 @@ rules:
       to_server: true
   - name: "sid:2067086"
     description: "ET INFO NTLMv1 Session Setup Response - Challenge"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     src_port:
@@ -451933,8 +450128,7 @@ rules:
       to_server: true
   - name: "sid:2067186"
     description: "ET WEB_SERVER GNU InetUtils Authentication Bypass via USER Environment Variable (CVE-2026-24061)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -454012,8 +452206,7 @@ rules:
       to_server: true
   - name: "sid:2067417"
     description: "ET EXPLOIT Quest KACE Desktop Authority Insecure Named Pipe AdminExec Operation (CVE-2025-67813)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,5}(?-i:SMB).*?(?-i:��\u0000��\u0000��\u0012A\u0000d\u0000m\u0000i\u0000n\u0000E\u0000x\u0000e\u0000c\u0000)"
@@ -454026,8 +452219,7 @@ rules:
         flag: "ET.QuestKACE.SMB"
   - name: "sid:2067418"
     description: "ET EXPLOIT Quest KACE Desktop Authority Insecure Named Pipe DllInjection Operation (CVE-2025-67813)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,5}(?-i:SMB).*?(?-i:��\u0000��\u0000��\u0018D\u0000l\u0000l\u0000I\u0000n\u0000j\u0000e\u0000c\u0000t\u0000i\u0000o\u0000n\u0000)"
@@ -454040,8 +452232,7 @@ rules:
         flag: "ET.QuestKACE.SMB"
   - name: "sid:2067419"
     description: "ET EXPLOIT Quest KACE Desktop Authority Insecure Named Pipe Credentials Operation (CVE-2025-67813)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,5}(?-i:SMB).*?(?-i:��\u0000��\u0000��\u0016C\u0000r\u0000e\u0000d\u0000e\u0000n\u0000t\u0000i\u0000a\u0000l\u0000s\u0000)"
@@ -454054,8 +452245,7 @@ rules:
         flag: "ET.QuestKACE.SMB"
   - name: "sid:2067421"
     description: "ET EXPLOIT Quest KACE Desktop Authority Insecure Named Pipe InvokeCOM Operation (CVE-2025-67813)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,5}(?-i:SMB).*?(?-i:��\u0012I\u0000n\u0000v\u0000o\u0000k\u0000e\u0000C\u0000O\u0000M\u0000)"
@@ -454068,8 +452258,7 @@ rules:
         flag: "ET.QuestKACE.SMB"
   - name: "sid:2067420"
     description: "ET EXPLOIT Quest KACE Desktop Authority Insecure Named Pipe ImpersonateAdmin Operation (CVE-2025-67813)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.{0,5}(?-i:SMB).*?(?-i:��\u0000��\u0000��\\ I\u0000m\u0000p\u0000e\u0000r\u0000s\u0000o\u0000n\u0000a\u0000t\u0000e\u0000A\u0000d\u0000m\u0000i\u0000n\u0000)"
@@ -457579,8 +455768,7 @@ rules:
       to_server: true
   - name: "sid:2067862"
     description: "ET MALWARE MoonRise CnC Commands Inbound via WebSocket"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -462145,8 +460333,7 @@ rules:
       to_client: true
   - name: "sid:2068415"
     description: "ET EXPLOIT Telnet SLC Option Data Buffer Overflow Attempt (CVE-2026-32746)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:��\").{109,}(?-i:��)"
@@ -467266,8 +465453,7 @@ rules:
       to_server: true
   - name: "sid:2069042"
     description: "ET INFO IKEv2 SA_INIT with Microsoft Security Realm Vendor ID"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -468457,8 +466643,7 @@ rules:
         flag: "ET.MaskGramStealer"
   - name: "sid:2069171"
     description: "ET WEB_SERVER Cisco IOS Authenticated SNMP Remote Code Execution (CVE-2025-20352)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     dst_port:
       ports: [161]
@@ -470308,8 +468493,7 @@ rules:
         flag: "ET.implantjs.syn"
   - name: "sid:2060266"
     description: "ET MALWARE implant.js CnC Activity (Evil Module Execution=Fail)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -470323,8 +468507,7 @@ rules:
         flag: "ET.implantjs.ack"
   - name: "sid:2060255"
     description: "ET MALWARE implant.js Linux Beacon Check-in"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -470340,8 +468523,7 @@ rules:
         flag: "ET.implantjs.syn"
   - name: "sid:2060256"
     description: "ET MALWARE implant.js Windows Beacon Check-in"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -470357,8 +468539,7 @@ rules:
         flag: "ET.implantjs.syn"
   - name: "sid:2060258"
     description: "ET MALWARE implant.js CnC Activity (Client PKT_FETCH for Evil Module)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -470374,8 +468555,7 @@ rules:
         flag: "ET.implantjs.ack"
   - name: "sid:2060259"
     description: "ET MALWARE implant.js CnC Activity (Evil Module Sent with DebugMode=ON)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -470389,8 +468569,7 @@ rules:
         flag: "ET.implantjs.ack"
   - name: "sid:2060260"
     description: "ET MALWARE implant.js CnC Activity (Evil Module Sent with DebugMode=OFF)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -470404,8 +468583,7 @@ rules:
         flag: "ET.implantjs.ack"
   - name: "sid:2060261"
     description: "ET MALWARE implant.js CnC Activity (Evil DBG_CMD_* Sent with DebugMode=ON)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -470468,8 +468646,7 @@ rules:
         flag: "ET.implantjs.ack"
   - name: "sid:2060263"
     description: "ET MALWARE implant.js Activity (DBG_RESP_* with DebugMode=ON)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -470532,8 +468709,7 @@ rules:
         flag: "ET.implantjs.ack"
   - name: "sid:2060265"
     description: "ET MALWARE implant.js CnC Activity (Evil Module Execution=Success)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -470930,8 +469106,7 @@ rules:
       to_server: true
   - name: "sid:2060957"
     description: "ET MALWARE Windows Shortcut Link Padded Whitespace in Command Line Arguments (ZDI-CAN-25373)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     action: traffic_attack
     regex:
       pattern: "(?s)\\A.*?(?-i:L\u0000\u0000\u0000\u0001\u0014\u0002\u0000\u0000\u0000\u0000\u0000�\u0000\u0000\u0000\u0000\u0000\u0000F�@\u0000\u0000).*?(?-i:^.*?(?:[\\x09\\x0a\\x0b\\x0c\\x0d\\x20]\\x00){25,})"
@@ -471182,8 +469357,7 @@ rules:
       to_server: true
   - name: "sid:2069474"
     description: "ET EXPLOIT Apache Tomcat Tribes EncryptInterceptor Bypass Remote Code Execution (CVE-2026-34486)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:
@@ -471281,8 +469455,7 @@ rules:
       to_server: true
   - name: "sid:2033078"
     description: "ET INFO Session Traversal Utilities for NAT (STUN Binding Request On Non-Standard High Port)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     regex:
@@ -471290,8 +469463,7 @@ rules:
       case_insensitive: false
   - name: "sid:2016149"
     description: "ET INFO Session Traversal Utilities for NAT (STUN Binding Request)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -471302,8 +469474,7 @@ rules:
       case_insensitive: false
   - name: "sid:2016150"
     description: "ET INFO Session Traversal Utilities for NAT (STUN Binding Response)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     src_port:
@@ -471314,8 +469485,7 @@ rules:
       case_insensitive: false
   - name: "sid:2033077"
     description: "ET INFO Session Traversal Utilities for NAT (STUN Binding Request On Non-Standard Low Port)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: udp
     action: traffic_attack
     dst_port:
@@ -482047,8 +480217,7 @@ rules:
         flag: "ET.PackClient_RAT.Infocheck"
   - name: "sid:2069890"
     description: "ET MALWARE PackClient RAT Desktop Screen Capture Exfiltration"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -483297,8 +481466,7 @@ rules:
       to_client: true
   - name: "sid:2070032"
     description: "ET MALWARE GoldenGh0stLoader Websocket Checkin - C2 Response"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     regex:
@@ -493014,8 +491182,7 @@ rules:
       to_server: true
   - name: "sid:2071165"
     description: "ET WEB_SERVER Check Point VPN IKEv1 (TCPT) Authentication Bypass (CVE-2026-50751)"
-    enabled: false
-    # disabled: binary content in pattern does not survive the SDK lossy decode
+    enabled: true
     protocol: tcp
     action: traffic_attack
     dst_port:

--- a/OpenEDR/owlyshield_predict/tools/convert_emerging_rules.py
+++ b/OpenEDR/owlyshield_predict/tools/convert_emerging_rules.py
@@ -131,10 +131,8 @@ def emit_rule(rule: dict) -> list:
     lines = ["  - name: %s" % yaml_quote(rule["name"])]
     if rule.get("description"):
         lines.append("    description: %s" % yaml_quote(rule["description"]))
-    enabled = rule.get("enabled", True)
-    lines.append("    enabled: %s" % ("true" if enabled else "false"))
-    if not enabled and rule.get("regex"):
-        lines.append("    # disabled: binary content in pattern does not survive the SDK lossy decode")
+    enabled = True
+    lines.append("    enabled: true")
     if rule.get("protocol"):
         lines.append("    protocol: %s" % rule["protocol"])
     lines.append("    action: %s" % rule["action"])
@@ -760,7 +758,7 @@ def convert_line(line: str, rule_index: int = 0):
         # byte in any binary payload (DNS/TLS/...) -> false-positive storm.
         # Such rules cannot be matched reliably, so disable them.
         if "\ufffd" in regex_terms[0]:
-            rule["enabled"] = False
+            rule["enabled"] = True
             stats["disabled_binary_regex"] += 1
     if ip_proto is not None:
         rule["ip_proto"] = ip_proto


### PR DESCRIPTION
Modified OpenEDR's convert_emerging_rules.py utility to always produce rules with enabled: true (bypassing the binary/lossy-decode check that previously disabled rules containing non-UTF-8 characters). Re-ran the converter on emerging-all.rules to update and enable all rules in emerging-all.yaml.

---
*PR created automatically by Jules for task [2268610762043157643](https://jules.google.com/task/2268610762043157643) started by @Siradankullanici*